### PR TITLE
Pool-level Stale share handling

### DIFF
--- a/scripts/main/api.js
+++ b/scripts/main/api.js
@@ -485,6 +485,7 @@ const PoolApi = function (client, poolConfigs, portalConfig) {
           },
           shares: {
             valid: parseFloat(results[4] ? results[4].valid || 0 : 0),
+            stale: parseFloat(results[4] ? results[4].stale || 0 : 0),
             invalid: parseFloat(results[4] ? results[4].invalid || 0 : 0),
           },
           hashrate: {
@@ -523,6 +524,7 @@ const PoolApi = function (client, poolConfigs, portalConfig) {
           },
           shares: {
             valid: parseFloat(results[12] ? results[12].valid || 0 : 0),
+            stale: parseFloat(results[12] ? results[12].stale || 0 : 0),
             invalid: parseFloat(results[12] ? results[12].invalid || 0 : 0),
           },
           hashrate: {

--- a/scripts/main/loader.js
+++ b/scripts/main/loader.js
@@ -108,7 +108,7 @@ const PoolLoader = function(logger, portalConfig) {
   this.validatePoolRecipients = function(poolConfig) {
     if (poolConfig.primary.recipients && poolConfig.primary.recipients.length >= 1) {
       const recipientTotal = poolConfig.primary.recipients.reduce((p_sum, a) => p_sum + a.percentage, 0);
-      if (recipientTotal > 1) {
+      if (recipientTotal >= 1) {
         logger.error('Builder', 'Setup', `Recipient percentage for ${ poolConfig.name } is greater than 100%. Check your configuration files`);
         return false;
       } else if (recipientTotal >= 0.4) {

--- a/scripts/main/loader.js
+++ b/scripts/main/loader.js
@@ -108,7 +108,7 @@ const PoolLoader = function(logger, portalConfig) {
   this.validatePoolRecipients = function(poolConfig) {
     if (poolConfig.primary.recipients && poolConfig.primary.recipients.length >= 1) {
       const recipientTotal = poolConfig.primary.recipients.reduce((p_sum, a) => p_sum + a.percentage, 0);
-      if (recipientTotal >= 1) {
+      if (recipientTotal > 1) {
         logger.error('Builder', 'Setup', `Recipient percentage for ${ poolConfig.name } is greater than 100%. Check your configuration files`);
         return false;
       } else if (recipientTotal >= 0.4) {

--- a/scripts/main/shares.js
+++ b/scripts/main/shares.js
@@ -80,12 +80,12 @@ const PoolShares = function (logger, client, poolConfig, portalConfig) {
 
   // Manage Shares Calculations
   /* istanbul ignore next */
-  this.calculateShares = function(results, shareData, shareValid, blockValid, blockType, isSoloMining) {
-
+  this.calculateShares = function(results, shareData, shareType, blockValid, blockType, isSoloMining) {
+    
     let shares;
     const commands = [];
     const dateNow = Date.now();
-    const difficulty = (shareValid ? shareData.difficulty : -shareData.difficulty);
+    const difficulty = (shareType.valid ? shareData.difficulty : -shareData.difficulty);
     const minerType = isSoloMining ? 'solo' : 'shared';
 
     const worker = ['share', 'primary'].includes(blockType) ? shareData.addrPrimary : shareData.addrAuxiliary;
@@ -138,12 +138,12 @@ const PoolShares = function (logger, client, poolConfig, portalConfig) {
     hashrateShare.difficulty = difficulty;
 
     // No Shared Effort if Solo Share
-    if (shareValid && isSoloMining) {
+    if (shareType.valid && isSoloMining) {
       commands.push(['zadd', `${ _this.pool }:rounds:${ blockType }:current:${ minerType }:hashrate`, dateNow / 1000 | 0, JSON.stringify(hashrateShare)]);
       commands.push(['hset', `${ _this.pool }:rounds:${ blockType }:current:${ minerType }:shares`, worker, JSON.stringify(outputShare)]);
 
     // Handle Shared Effort, Share Updates
-    } else if (shareValid) {
+    } else if (shareType.valid) {
       commands.push(['zadd', `${ _this.pool }:rounds:${ blockType }:current:${ minerType }:hashrate`, dateNow / 1000 | 0, JSON.stringify(hashrateShare)]);
       commands.push(['hincrby', `${ _this.pool }:rounds:${ blockType }:current:${ minerType }:counts`, 'valid', 1]);
       commands.push(['hset', `${ _this.pool }:rounds:${ blockType }:current:${ minerType }:shares`, worker, JSON.stringify(outputShare)]);
@@ -152,7 +152,11 @@ const PoolShares = function (logger, client, poolConfig, portalConfig) {
     // Handle Invalid Shares Submitted
     } else {
       commands.push(['zadd', `${ _this.pool }:rounds:${ blockType }:current:${ minerType }:hashrate`, dateNow / 1000 | 0, JSON.stringify(hashrateShare)]);
-      commands.push(['hincrby', `${ _this.pool }:rounds:${ blockType }:current:${ minerType }:counts`, 'invalid', 1]);
+      if (shareType.stale) {
+        commands.push(['hincrby', `${ _this.pool }:rounds:${ blockType }:current:${ minerType }:counts`, 'stale', 1]);
+      } else {
+        commands.push(['hincrby', `${ _this.pool }:rounds:${ blockType }:current:${ minerType }:counts`, 'invalid', 1]);
+      }
     }
 
     return commands;
@@ -160,13 +164,13 @@ const PoolShares = function (logger, client, poolConfig, portalConfig) {
 
   // Manage Blocks Calculations
   /* istanbul ignore next */
-  this.calculateBlocks = function(results, shareData, shareValid, blockValid, isSoloMining) {
+  this.calculateBlocks = function(results, shareData, shareType, blockValid, isSoloMining) {
 
     let shares;
     const commands = [];
     const dateNow = Date.now();
     const blockType = shareData.blockType;
-    const difficulty = (shareValid ? shareData.difficulty : -shareData.difficulty);
+    const difficulty = (shareType.valid ? shareData.difficulty : -shareData.difficulty);
     const minerType = isSoloMining ? 'solo' : 'shared';
 
     const worker = ['share', 'primary'].includes(blockType) ? shareData.addrPrimary : shareData.addrAuxiliary;
@@ -259,9 +263,9 @@ const PoolShares = function (logger, client, poolConfig, portalConfig) {
   };
 
   // Manage Worker Times
-  this.buildTimesCommands = function(results, shareData, shareValid, blockValid, isSoloMining) {
+  this.buildTimesCommands = function(results, shareData, shareType, blockValid, isSoloMining) {
     let commands = [];
-    if (shareValid && !isSoloMining) {
+    if (shareType.valid && !isSoloMining) {
       commands = commands.concat(_this.calculateTimes(results[1], shareData.addrPrimary, blockValid, 'primary', isSoloMining));
       if (_this.poolConfig.auxiliary && _this.poolConfig.auxiliary.enabled) {
         commands = commands.concat(_this.calculateTimes(results[3], shareData.addrAuxiliary, blockValid, 'auxiliary', isSoloMining));
@@ -271,23 +275,24 @@ const PoolShares = function (logger, client, poolConfig, portalConfig) {
   };
 
   // Manage Worker Times
-  this.buildSharesCommands = function(results, shareData, shareValid, blockValid, isSoloMining) {
+  this.buildSharesCommands = function(results, shareData, shareType, blockValid, isSoloMining) {
     let commands = [];
-    commands = commands.concat(_this.buildTimesCommands(results, shareData, shareValid, blockValid, isSoloMining));
-    commands = commands.concat(_this.calculateShares(results, shareData, shareValid, blockValid, 'primary', isSoloMining));
+    
+    commands = commands.concat(_this.buildTimesCommands(results, shareData, shareType, blockValid, isSoloMining));
+    commands = commands.concat(_this.calculateShares(results, shareData, shareType, blockValid, 'primary', isSoloMining));
     if (_this.poolConfig.auxiliary && _this.poolConfig.auxiliary.enabled) {
-      commands = commands.concat(_this.calculateShares(results, shareData, shareValid, blockValid, 'auxiliary', isSoloMining));
+      commands = commands.concat(_this.calculateShares(results, shareData, shareType, blockValid, 'auxiliary', isSoloMining));
     }
     return commands;
   };
 
 
   // Build Redis Commands
-  this.buildCommands = function(results, shareData, shareValid, blockValid, callback, handler) {
+  this.buildCommands = function(results, shareData, shareType, blockValid, callback, handler) {
     let commands = [];
     const isSoloMining = utils.checkSoloMining(_this.poolConfig, shareData);
-    commands = commands.concat(_this.buildSharesCommands(results, shareData, shareValid, blockValid, isSoloMining));
-    commands = commands.concat(_this.calculateBlocks(results, shareData, shareValid, blockValid, isSoloMining));
+    commands = commands.concat(_this.buildSharesCommands(results, shareData, shareType, blockValid, isSoloMining));
+    commands = commands.concat(_this.calculateBlocks(results, shareData, shareType, blockValid, isSoloMining));
     this.executeCommands(commands, callback, handler);
     return commands;
   };
@@ -307,7 +312,7 @@ const PoolShares = function (logger, client, poolConfig, portalConfig) {
 
   // Handle Share Submissions
   /* istanbul ignore next */
-  this.handleShares = function(shareData, shareValid, blockValid, callback, handler) {
+  this.handleShares = function(shareData, shareType, blockValid, callback, handler) {
     const shareLookups = [
       ['hgetall', `${ _this.pool }:rounds:primary:current:shared:shares`],
       ['hgetall', `${ _this.pool }:rounds:primary:current:shared:submissions`],
@@ -318,7 +323,7 @@ const PoolShares = function (logger, client, poolConfig, portalConfig) {
       ['hgetall', `${ _this.pool }:rounds:auxiliary:current:solo:shares`],
       ['hgetall', `${ _this.pool }:rounds:auxiliary:current:solo:submissions`]];
     this.executeCommands(shareLookups, (results) => {
-      _this.buildCommands(results, shareData, shareValid, blockValid, callback, handler);
+      _this.buildCommands(results, shareData, shareType, blockValid, callback, handler);
     }, handler);
   };
 };

--- a/scripts/main/stratum.js
+++ b/scripts/main/stratum.js
@@ -43,10 +43,13 @@ const PoolStratum = function (logger, poolConfig, poolShares, poolStatistics) {
   };
 
   // Determine Share Viability
-  this.checkShare = function(shareData, shareValid) {
-    if (!shareValid) {
+  this.checkShare = function(shareData, shareType) {
+    if (shareType.stale) {
+      logger.debug(logSystem, logComponent, logSubCat, 'We thought a share was found but it was stale and rejected by the daemon.');
+    } else if (shareType.invalid) {
       logger.debug(logSystem, logComponent, logSubCat, 'We thought a share was found but it was rejected by the daemon.');
-    } else if (shareData.blockType !== 'auxiliary') {
+    }
+      else if (shareData.blockType !== 'auxiliary') {
       logger.debug(logSystem, logComponent, logSubCat, `Share accepted at difficulty ${ shareData.difficulty }/${ shareData.shareDiff } by ${ shareData.addrPrimary } [${ shareData.ip }]`);
     }
   };
@@ -96,11 +99,11 @@ const PoolStratum = function (logger, poolConfig, poolShares, poolStatistics) {
 
   // Handle Share Submissions
   /* istanbul ignore next */
-  this.handleShares = function(shareData, shareValid, blockValid, callback) {
-    _this.poolShares.handleShares(shareData, shareValid, blockValid, () => {
+  this.handleShares = function(shareData, shareType, blockValid, callback) {
+    _this.poolShares.handleShares(shareData, shareType, blockValid, () => {
       _this.checkPrimary(shareData, blockValid);
       _this.checkAuxiliary(shareData, blockValid);
-      _this.checkShare(shareData, shareValid);
+      _this.checkShare(shareData, shareType);
       callback();
     }, () => {});
   };
@@ -116,8 +119,8 @@ const PoolStratum = function (logger, poolConfig, poolShares, poolStatistics) {
     poolStratum.on('difficultyUpdate', (workerName, diff) => {
       logger.debug(logSystem, logComponent, logSubCat, `Difficulty update to ${ diff } for worker: ${ JSON.stringify(workerName) }`);
     });
-    poolStratum.on('share', (shareData, shareValid, blockValid, callback) => {
-      _this.handleShares(shareData, shareValid, blockValid, callback);
+    poolStratum.on('share', (shareData, shareType, blockValid, callback) => {
+      _this.handleShares(shareData, shareType, blockValid, callback);
     });
     return poolStratum;
   };

--- a/scripts/test/api.test.js
+++ b/scripts/test/api.test.js
@@ -776,6 +776,7 @@ describe('Test API functionality', () => {
       ['hset', 'Pool1:payments:primary:counts', 'last', 0],
       ['hset', 'Pool1:payments:primary:counts', 'next', 1],
       ['hset', 'Pool1:rounds:primary:current:shared:counts', 'valid', 3190],
+      ['hset', 'Pool1:rounds:primary:current:shared:counts', 'stale', 345],
       ['hset', 'Pool1:rounds:primary:current:shared:counts', 'invalid', 465],
       ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', solo: true, difficulty: 32 })],
       ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', solo: false, difficulty: 64 })],
@@ -800,6 +801,7 @@ describe('Test API functionality', () => {
       expect(processed.body.primary.payments.next).toBe(1);
       expect(processed.body.primary.payments.total).toBe(200.5);
       expect(processed.body.primary.shares.invalid).toBe(465);
+      expect(processed.body.primary.shares.stale).toBe(345);
       expect(processed.body.primary.shares.valid).toBe(3190);
       expect(processed.body.primary.hashrate.shared).toBe(2576980377.6);
       expect(processed.body.primary.status.miners).toBe(6);
@@ -827,6 +829,7 @@ describe('Test API functionality', () => {
       ['hset', 'Pool1:payments:primary:counts', 'last', 0],
       ['hset', 'Pool1:payments:primary:counts', 'next', 1],
       ['hset', 'Pool1:rounds:primary:current:shared:counts', 'valid', 3190],
+      ['hset', 'Pool1:rounds:primary:current:shared:counts', 'stale', 345],
       ['hset', 'Pool1:rounds:primary:current:shared:counts', 'invalid', 465],
       ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', solo: true, difficulty: 32 })],
       ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', solo: false, difficulty: 64 })],
@@ -851,6 +854,7 @@ describe('Test API functionality', () => {
       expect(processed.body.primary.payments.next).toBe(1);
       expect(processed.body.primary.payments.total).toBe(200.5);
       expect(processed.body.primary.shares.invalid).toBe(465);
+      expect(processed.body.primary.shares.stale).toBe(345);
       expect(processed.body.primary.shares.valid).toBe(3190);
       expect(processed.body.primary.hashrate.shared).toBe(2576980377.6);
       expect(processed.body.primary.status.miners).toBe(6);

--- a/scripts/test/loader.test.js
+++ b/scripts/test/loader.test.js
@@ -69,14 +69,14 @@ describe('Test loader functionality', () => {
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     const algorithms = { mining: 'scrypt', block: 'sha256d', coinbase: 'sha256d' };
     const poolLoader = new PoolLoader(logger, configCopy);
-    const poolConfig = { enabled: true, primary: { coin: { algorithms: algorithms }, recipients: [{ percentage: 1 }]}};
+    const poolConfig = { enabled: true, primary: { coin: { algorithms: algorithms }, recipients: [{ percentage: 0.9 }]}};
     const response = poolLoader.validatePoolConfigs(poolConfig);
     expect(consoleSpy).toHaveBeenCalled();
     expect(response).toBe(false);
     console.log.mockClear();
   });
 
-  test('Test pool configuration validation [5]', () => {
+  test('Test pool configuration validation [6]', () => {
     const poolLoader = new PoolLoader(logger, configCopy);
     const poolConfig = { enabled: false, name: 'Litecoin', primary: { coin: { name: 'Litecoin' }}};
     const response = poolLoader.validatePoolConfigs(poolConfig);

--- a/scripts/test/loader.test.js
+++ b/scripts/test/loader.test.js
@@ -69,7 +69,7 @@ describe('Test loader functionality', () => {
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     const algorithms = { mining: 'scrypt', block: 'sha256d', coinbase: 'sha256d' };
     const poolLoader = new PoolLoader(logger, configCopy);
-    const poolConfig = { enabled: true, primary: { coin: { algorithms: algorithms }, recipients: [{ percentage: 0.9 }]}};
+    const poolConfig = { enabled: true, primary: { coin: { algorithms: algorithms }, recipients: [{ percentage: 1 }]}};
     const response = poolLoader.validatePoolConfigs(poolConfig);
     expect(consoleSpy).toHaveBeenCalled();
     expect(response).toBe(false);

--- a/scripts/test/shares.test.js
+++ b/scripts/test/shares.test.js
@@ -110,7 +110,7 @@ describe('Test shares functionality', () => {
     const expected = [
       ['hincrbyfloat', 'Pool1:rounds:primary:current:shared:times', 'example'],
       ['hset', 'Pool1:rounds:primary:current:shared:submissions', 'example']];
-    const commands = poolShares.buildTimesCommands(results, shareData, true, false, false);
+    const commands = poolShares.buildTimesCommands(results, shareData, { valid: true, stale: false, invalid: false }, false, false);
     expect(commands.length).toBe(2);
     expect(commands[0].slice(0, 3)).toStrictEqual(expected[0]);
     expect(commands[1].slice(0, 3)).toStrictEqual(expected[1]);
@@ -138,7 +138,7 @@ describe('Test shares functionality', () => {
       'shareDiff': '2.35170820',
     };
     const expected = [['hset', 'Pool1:rounds:primary:current:shared:submissions', 'example']];
-    const commands = poolShares.buildTimesCommands(results, shareData, true, false, false);
+    const commands = poolShares.buildTimesCommands(results, shareData, { valid: true, stale: false, invalid: false }, false, false);
     expect(commands.length).toBe(1);
     expect(commands[0].slice(0, 3)).toStrictEqual(expected[0]);
     expect(utils.roundTo(commands[0].slice(3)[0] / 1000)).toBe(utils.roundTo(dateNow / 1000));
@@ -164,7 +164,7 @@ describe('Test shares functionality', () => {
       'shareDiff': '2.35170820',
     };
     const expected = [['hincrbyfloat', 'Pool1:rounds:primary:current:shared:times', 'example']];
-    const commands = poolShares.buildTimesCommands(results, shareData, true, true, false);
+    const commands = poolShares.buildTimesCommands(results, shareData, { valid: true, stale: false, invalid: false }, true, false);
     expect(commands.length).toBe(1);
     expect(commands[0].slice(0, 3)).toStrictEqual(expected[0]);
     expect(utils.roundTo(commands[0].slice(3)[0])).toBe(300);
@@ -195,7 +195,7 @@ describe('Test shares functionality', () => {
       ['hset', 'Pool1:rounds:primary:current:shared:submissions', 'example1'],
       ['hincrbyfloat', 'Pool1:rounds:auxiliary:current:shared:times', 'example2'],
       ['hset', 'Pool1:rounds:auxiliary:current:shared:submissions', 'example2']];
-    const commands = poolShares.buildTimesCommands(results, shareData, true, false, false);
+    const commands = poolShares.buildTimesCommands(results, shareData, { valid: true, stale: false, invalid: false }, false, false);
     expect(commands.length).toBe(4);
     expect(commands[0].slice(0, 3)).toStrictEqual(expected[0]);
     expect(commands[1].slice(0, 3)).toStrictEqual(expected[1]);

--- a/scripts/test/shares.test.js
+++ b/scripts/test/shares.test.js
@@ -233,7 +233,7 @@ describe('Test shares functionality', () => {
       ['hincrby', 'Pool1:rounds:primary:current:shared:counts', 'valid', 1],
       ['hset', 'Pool1:rounds:primary:current:shared:shares'],
       ['hset', 'Pool1:rounds:primary:current:shared:counts', 'effort', 7.277845022124848e-7]];
-    const commands = poolShares.buildSharesCommands(results, shareData, true, false, false);
+    const commands = poolShares.buildSharesCommands(results, shareData, { valid: true, stale: false, invalid: false }, false, false);
     expect(commands.length).toBe(6);
     expect(commands[0].slice(0, 3)).toStrictEqual(expected[0]);
     expect(commands[1].slice(0, 3)).toStrictEqual(expected[1]);
@@ -265,7 +265,7 @@ describe('Test shares functionality', () => {
     const expected = [
       ['zadd', 'Pool1:rounds:primary:current:shared:hashrate'],
       ['hincrby', 'Pool1:rounds:primary:current:shared:counts', 'invalid', 1]];
-    const commands = poolShares.buildSharesCommands(results, shareData, false, true, false);
+    const commands = poolShares.buildSharesCommands(results, shareData, { valid: false, stale: false, invalid: true }, true, false);
     expect(commands.length).toBe(2);
     expect(commands[0].slice(0, 2)).toStrictEqual(expected[0]);
     expect(commands[1]).toStrictEqual(expected[1]);
@@ -305,7 +305,7 @@ describe('Test shares functionality', () => {
       ['hincrby', 'Pool1:rounds:auxiliary:current:shared:counts', 'valid', 1],
       ['hset', 'Pool1:rounds:auxiliary:current:shared:shares'],
       ['hset', 'Pool1:rounds:auxiliary:current:shared:counts', 'effort', 28.57142857142857]];
-    const commands = poolShares.buildSharesCommands(results, shareData, true, false, false);
+    const commands = poolShares.buildSharesCommands(results, shareData, { valid: true, stale: false, invalid: false }, false, false);
     expect(commands.length).toBe(12);
     expect(commands[0].slice(0, 3)).toStrictEqual(expected[0]);
     expect(commands[1].slice(0, 3)).toStrictEqual(expected[1]);
@@ -343,7 +343,7 @@ describe('Test shares functionality', () => {
     const expected = [
       ['zadd', 'Pool1:rounds:primary:current:solo:hashrate'],
       ['hset', 'Pool1:rounds:primary:current:solo:shares', 'example']];
-    const commands = poolShares.buildSharesCommands(results, shareData, true, false, true);
+    const commands = poolShares.buildSharesCommands(results, shareData, { valid: true, stale: false, invalid: false }, false, true);
     expect(commands.length).toBe(2);
     expect(commands[0].slice(0, 2)).toStrictEqual(expected[0]);
     expect(commands[1].slice(0, 3)).toStrictEqual(expected[1]);
@@ -377,7 +377,7 @@ describe('Test shares functionality', () => {
       ['hincrby', 'Pool1:rounds:primary:current:shared:counts', 'valid', 1],
       ['hset', 'Pool1:rounds:primary:current:shared:shares', 'example'],
       ['hset', 'Pool1:rounds:primary:current:shared:counts', 'effort', 0.0000014555690044249697]];
-    const commands = poolShares.buildSharesCommands(results, shareData, true, false, false);
+    const commands = poolShares.buildSharesCommands(results, shareData, { valid: true, stale: false, invalid: false }, false, false);
     expect(commands.length).toBe(6);
     expect(commands[0].slice(0, 3)).toStrictEqual(expected[0]);
     expect(commands[1].slice(0, 3)).toStrictEqual(expected[1]);
@@ -416,7 +416,7 @@ describe('Test shares functionality', () => {
       ['hincrby', 'Pool1:rounds:primary:current:shared:counts', 'valid', 1],
       ['hset', 'Pool1:rounds:primary:current:shared:shares', 'example'],
       ['hset', 'Pool1:rounds:primary:current:shared:counts', 'effort', 0.0000014555690044249697]];
-    const commands = poolShares.buildSharesCommands(results, shareData, true, false, false);
+    const commands = poolShares.buildSharesCommands(results, shareData, { valid: true, stale: false, invalid: false }, false, false);
     expect(commands.length).toBe(6);
     expect(commands[0].slice(0, 3)).toStrictEqual(expected[0]);
     expect(commands[1].slice(0, 3)).toStrictEqual(expected[1]);
@@ -426,6 +426,34 @@ describe('Test shares functionality', () => {
     expect(JSON.parse(commands[4][3]).difficulty).toBe(1);
     expect(commands[5]).toStrictEqual(expected[5]);
     expect();
+  });
+
+  test('Test share command handling [7]', () => {
+    const dateNow = Date.now();
+    const poolShares = new PoolShares(logger, client, poolConfigCopy, configCopy);
+    const results = [{}, { 'example': dateNow - 300000 }, {}, {}];
+    const shareData = {
+      'job': '4',
+      'ip': '::1',
+      'port': 3002,
+      'addrPrimary': 'example',
+      'addrAuxiliary': null,
+      'blockDiffPrimary': 137403310.58987552,
+      'blockType': 'primary',
+      'difficulty': 1,
+      'hash': null,
+      'hashInvalid': null,
+      'height': 1972211,
+      'reward': 10006839,
+      'shareDiff': '2.35170820',
+    };
+    const expected = [
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate'],
+      ['hincrby', 'Pool1:rounds:primary:current:shared:counts', 'stale', 1]];
+    const commands = poolShares.buildSharesCommands(results, shareData, { valid: false, stale: true, invalid: false }, true, false);
+    expect(commands.length).toBe(2);
+    expect(commands[0].slice(0, 2)).toStrictEqual(expected[0]);
+    expect(commands[1]).toStrictEqual(expected[1]);
   });
 
   test('Test block command handling [1]', () => {
@@ -625,7 +653,7 @@ describe('Test shares functionality', () => {
       ['hincrby', 'Pool1:rounds:primary:current:shared:counts', 'valid', 1],
       ['hset', 'Pool1:rounds:primary:current:shared:shares'],
       ['hset', 'Pool1:rounds:primary:current:shared:counts', 'effort', 7.277845022124848e-7]];
-    const commands = poolShares.buildCommands(results, shareData, true, false, () => {
+    const commands = poolShares.buildCommands(results, shareData, { valid: true, stale: false, invalid: false }, false, () => {
       return done();
     });
     expect(commands.length).toBe(6);

--- a/scripts/test/shares.test.js
+++ b/scripts/test/shares.test.js
@@ -80,7 +80,7 @@ describe('Test shares functionality', () => {
     const expected = [
       ['hincrbyfloat', 'Pool1:rounds:primary:current:shared:times', 'example'],
       ['hset', 'Pool1:rounds:primary:current:shared:submissions', 'example']];
-    const commands = poolShares.buildTimesCommands(results, shareData, true, false);
+    const commands = poolShares.buildTimesCommands(results, shareData, { valid: true, stale: false, invalid: false }, false);
     expect(commands.length).toBe(2);
     expect(commands[0].slice(0, 3)).toStrictEqual(expected[0]);
     expect(commands[1].slice(0, 3)).toStrictEqual(expected[1]);

--- a/scripts/test/stratum.test.js
+++ b/scripts/test/stratum.test.js
@@ -97,7 +97,7 @@ describe('Test stratum functionality', () => {
   test('Test share viability checker [1]', () => {
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     const poolStratum = new PoolStratum(logger, configCopy, poolShares);
-    poolStratum.checkShare({}, false);
+    poolStratum.checkShare({}, { valid: false, stale: false, invalid: true });
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringMatching('We thought a share was found but it was rejected by the daemon'));
     console.log.mockClear();
   });
@@ -105,7 +105,7 @@ describe('Test stratum functionality', () => {
   test('Test share viability checker [2]', () => {
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     const poolStratum = new PoolStratum(logger, configCopy, poolShares);
-    poolStratum.checkShare({}, true);
+    poolStratum.checkShare({}, { valid: true, stale: false, invalid: false });
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringMatching('Share accepted at difficulty'));
     console.log.mockClear();
   });
@@ -113,8 +113,16 @@ describe('Test stratum functionality', () => {
   test('Test share viability checker [3]', () => {
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     const poolStratum = new PoolStratum(logger, configCopy, poolShares);
-    poolStratum.checkShare({ blockType: 'auxiliary' }, true);
+    poolStratum.checkShare({ blockType: 'auxiliary' }, { valid: true, stale: false, invalid: false });
     expect(consoleSpy).not.toHaveBeenCalled();
+    console.log.mockClear();
+  });
+
+  test('Test share viability checker [4]', () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const poolStratum = new PoolStratum(logger, configCopy, poolShares);
+    poolStratum.checkShare({}, { valid: false, stale: true, invalid: false });
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringMatching('We thought a share was found but it was stale and rejected by the daemon.'));
     console.log.mockClear();
   });
 

--- a/scripts/test/stratum.test.js
+++ b/scripts/test/stratum.test.js
@@ -302,7 +302,7 @@ describe('Test stratum functionality', () => {
       'worker': 'example'
     };
     poolStratum.setupStratum(() => {
-      poolStratum.handleShares(shareData, true, false, () => {
+      poolStratum.handleShares(shareData, { valid: true, stale: false, invalid: false }, false, () => {
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringMatching('Share accepted at difficulty'));
         poolStratum.poolStratum.stratum.stopServer();
         console.log.mockClear();


### PR DESCRIPTION
Stale shares are recorded at pool level and exported via the /statistics endpoint. 