### PR TITLE
Blocks and payments per miner

### DIFF
--- a/scripts/main/api.js
+++ b/scripts/main/api.js
@@ -351,7 +351,6 @@ const PoolApi = function (client, poolConfigs, portalConfig) {
         ['zrangebyscore', `${ pool }:payments:primary:minerpayments`, '-inf', '+inf'],
         ['zrangebyscore', `${ pool }:payments:auxiliary:minerpayments`, '-inf', '+inf']];
       _this.executeCommands(commands, (results) => {
-        console.log(results[0]);
         callback(200, {
           primary: utils.processMinerPayments(results[0], miner),
           auxiliary: utils.processMinerPayments(results[1], miner),

--- a/scripts/main/api.js
+++ b/scripts/main/api.js
@@ -112,7 +112,7 @@ const PoolApi = function (client, poolConfigs, portalConfig) {
           pending: utils.listBlocks(results[5], miner),
         }
       });
-      console.log('something confirmed:' + results[0]);
+      console.log('something confirmed:' + results[2]);
     }, callback);
   };
 

--- a/scripts/main/api.js
+++ b/scripts/main/api.js
@@ -112,7 +112,6 @@ const PoolApi = function (client, poolConfigs, portalConfig) {
           pending: utils.listBlocks(results[5], miner),
         }
       });
-      console.log('something confirmed:' + results[2]);
     }, callback);
   };
 

--- a/scripts/main/api.js
+++ b/scripts/main/api.js
@@ -351,6 +351,7 @@ const PoolApi = function (client, poolConfigs, portalConfig) {
         ['zrangebyscore', `${ pool }:payments:primary:minerpayments`, '-inf', '+inf'],
         ['zrangebyscore', `${ pool }:payments:auxiliary:minerpayments`, '-inf', '+inf']];
       _this.executeCommands(commands, (results) => {
+        console.log(results[0]);
         callback(200, {
           primary: utils.processMinerPayments(results[0], miner),
           auxiliary: utils.processMinerPayments(results[1], miner),

--- a/scripts/main/api.js
+++ b/scripts/main/api.js
@@ -112,6 +112,7 @@ const PoolApi = function (client, poolConfigs, portalConfig) {
           pending: utils.listBlocks(results[5], miner),
         }
       });
+      console.log('something confirmed:' + results[0]);
     }, callback);
   };
 

--- a/scripts/main/payments.js
+++ b/scripts/main/payments.js
@@ -742,6 +742,17 @@ const PoolPayments = function (logger, client) {
           transaction: transaction,
         };
 
+        // Update Redis with miner payment records
+        for (const [address, amount] of Object.entries(amounts)) {
+          const entry = { 
+            time: currentDate,
+            paid: amount,
+            transaction: transaction,
+            miner: address,
+          };
+          commands.push(['zadd', `${ pool }:payments:${ blockType }:minerpayments`, Date.now() / 1000 | 0, JSON.stringify(entry)]);
+        }
+
         // Update Redis Database with Payment Record
         logger.special('Payments', pool, `Sent ${ totalSent } ${ processingConfig.coin.symbol } to ${ Object.keys(amounts).length } workers, txid: ${ transaction }`);
         commands.push(['zadd', `${ pool }:payments:${ blockType }:records`, Date.now(), JSON.stringify(payments)]);

--- a/scripts/main/utils.js
+++ b/scripts/main/utils.js
@@ -196,7 +196,9 @@ exports.processBlocks = function(blocks) {
 exports.listBlocks = function(blockData, miner) {
   const blocks = [];
   if (blockData) {
-    blockData = blockData.map((block) => JSON.parse(block));
+    blockData = blockData
+      .map((block) => JSON.parse(block))
+      .sort((a, b) => (b.height - a.height));
     blockData.forEach((block) => {
       if (block.worker.split('.')[0] === miner) {
         blocks.push(block);

--- a/scripts/main/utils.js
+++ b/scripts/main/utils.js
@@ -199,6 +199,7 @@ exports.listBlocks = function(blockData, miner) {
     blockData = blockData.map((block) => JSON.parse(block));
     blockData.forEach((block) => {
       console.log(miner);
+      console.log(block.worker);
       if (block.worker === miner) {
         blocks.push(block);
       }

--- a/scripts/main/utils.js
+++ b/scripts/main/utils.js
@@ -199,7 +199,7 @@ exports.listBlocks = function(blockData, miner) {
     blockData = blockData.map((block) => JSON.parse(block));
     blockData.forEach((block) => {
       console.log(miner);
-      console.log(block.worker);
+      console.log(block.worker.split('.')[0]);
       if (block.worker === miner) {
         blocks.push(block);
       }

--- a/scripts/main/utils.js
+++ b/scripts/main/utils.js
@@ -192,6 +192,20 @@ exports.processBlocks = function(blocks) {
   return output;
 };
 
+// List Blocks per miner for API Endpoints
+exports.listBlocks = function(blockData, miner) {
+  const blocks = [];
+  if (blockData) {
+    blockData = blockData.map((block) => JSON.parse(block));
+    blockData.forEach((block) => {
+      if (block.worker === miner) {
+        blocks.push(block);
+      }
+    });
+  }
+  return blocks;
+};
+
 // Process Difficulty for API Endpoints
 exports.processDifficulty = function(shares, miner, type) {
   let count = 0;
@@ -282,6 +296,21 @@ exports.processRecords = function(records) {
     .map((record) => JSON.parse(record))
     .sort((a, b) => (a.time - b.time));
 };
+
+// Process Payments for defined Miner for API Endpoints
+exports.processMinerPayments = function(paymentData, miner) {
+  const payments = [];
+  if (paymentData) {
+    paymentData = paymentData.map((payment) => JSON.parse(payment));
+    paymentData.forEach((payment) => {
+      if (payment.miner === miner) {
+        payments.push(payment);
+      }
+    });
+  }
+  return payments;
+};
+
 
 // Process Shares for API Endpoints
 exports.processShares = function(shares, miner) {

--- a/scripts/main/utils.js
+++ b/scripts/main/utils.js
@@ -198,6 +198,7 @@ exports.listBlocks = function(blockData, miner) {
   if (blockData) {
     blockData = blockData.map((block) => JSON.parse(block));
     blockData.forEach((block) => {
+      console.log(miner);
       if (block.worker === miner) {
         blocks.push(block);
       }

--- a/scripts/main/utils.js
+++ b/scripts/main/utils.js
@@ -198,8 +198,9 @@ exports.listBlocks = function(blockData, miner) {
   if (blockData) {
     blockData = blockData.map((block) => JSON.parse(block));
     blockData.forEach((block) => {
-      console.log(miner);
-      console.log(block.worker.split('.')[0]);
+      const test = block.worker.split('.')[0]
+      console.log('first: ' + test);
+      console.log('second: ' + test.split('.')[0]);
       if (block.worker === miner) {
         blocks.push(block);
       }

--- a/scripts/main/utils.js
+++ b/scripts/main/utils.js
@@ -198,10 +198,7 @@ exports.listBlocks = function(blockData, miner) {
   if (blockData) {
     blockData = blockData.map((block) => JSON.parse(block));
     blockData.forEach((block) => {
-      const test = block.worker.split('.')[0]
-      console.log('first: ' + test);
-      console.log('second: ' + test.split('.')[0]);
-      if (block.worker === miner) {
+      if (block.worker.split('.')[0] === miner) {
         blocks.push(block);
       }
     });

--- a/scripts/test/utils.test.js
+++ b/scripts/test/utils.test.js
@@ -330,6 +330,34 @@ describe('Test utility functionality', () => {
     expect(processed[1].worker).toBe('tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a');
   });
 
+  test('Test implemented listBlocks [1]', () => {
+    const miner = 'miner1';
+    const blocks = [
+      '{"time":1623901893182,"height":123456,"hash":"8de06f6e73dbff454023a95f29f87c3","reward":123,"transaction":"bc0b3f953ff408cfb298b034daf5ecd480","difficulty":234,"luck":34.56,"worker":"miner2","solo":false,"round":"12345678"}',
+      '{"time":1623901893183,"height":123457,"hash":"8de0623a95f29f6e73dbff4540f87c3","reward":123,"transaction":"b53ff408cfb298c0b3f9b034daf5ecd480","difficulty":234,"luck":34.56,"worker":"miner1","solo":false,"round":"12345679"}',
+      '{"time":1623901893184,"height":123458,"hash":"8de0bff4540236f6e73da95f29f87c3","reward":123,"transaction":"bc0b3f4daf5ecd4953ff408cfb298b0380","difficulty":234,"luck":34.56,"worker":"miner1","solo":false,"round":"12345680"}'];
+    const processed = utils.listBlocks(blocks, miner);
+    expect(processed.length).toBe(2);
+    expect(processed[0].height).toBe(123457);
+    expect(processed[1].height).toBe(123458);
+  });
+
+  test('Test implemented listBlocks [2]', () => {
+    const miner = 'miner3';
+    const blocks = [
+      '{"time":1623901893182,"height":123456,"hash":"8de06f6e73dbff454023a95f29f87c3","reward":123,"transaction":"bc0b3f953ff408cfb298b034daf5ecd480","difficulty":234,"luck":34.56,"worker":"miner2","solo":false,"round":"12345678"}',
+      '{"time":1623901893183,"height":123457,"hash":"8de0623a95f29f6e73dbff4540f87c3","reward":123,"transaction":"b53ff408cfb298c0b3f9b034daf5ecd480","difficulty":234,"luck":34.56,"worker":"miner1","solo":false,"round":"12345679"}',
+      '{"time":1623901893184,"height":123458,"hash":"8de0bff4540236f6e73da95f29f87c3","reward":123,"transaction":"bc0b3f4daf5ecd4953ff408cfb298b0380","difficulty":234,"luck":34.56,"worker":"miner1","solo":false,"round":"12345680"}'];
+    const processed = utils.listBlocks(blocks, miner);
+    expect(processed.length).toBe(0);
+  });
+
+  test('Test implemented listBlocks [3]', () => {
+    const miner = 'miner3';
+    const processed = utils.listBlocks(null, miner);
+    expect(processed.length).toBe(0);
+  });
+
   test('Test implemented processDifficulty [1]', () => {
     const shares = [
       '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8}',
@@ -655,6 +683,33 @@ describe('Test utility functionality', () => {
     expect(processed[0].paid).toBe(11.8749);
     expect(processed[0].transaction).toBe('31f5978a31a2bac842e383170b019e17415c12fd425f155269bafe7b4bb00a22');
     expect(processed[1].transaction).toBe('31f5978a31a2bac842e383170b019e17415c12fd425f155269bafe7b4bb00a21');
+  });
+
+  test('Test implemented processMinerPayments [1]', () => {
+    const miner = 'miner1';
+    const payments = [
+      '{"time":1623901893182,"paid":123.456,"transaction":"bc0b3f953ff408cfb298b034daf5ecd480","miner":"miner1"}',
+      '{"time":1623902893182,"paid":124.456,"transaction":"bc0b4f953ff408cfb298b034daf5ecd480","miner":"miner1"}',
+      '{"time":1623903893182,"paid":125.456,"transaction":"bc0b5f953ff408cfb298b034daf5ecd480","miner":"miner2"}'];
+    const processed = utils.processMinerPayments(payments, miner);
+    expect(processed.length).toBe(2);
+    expect(processed[0].time).toBe(1623901893182);
+    expect(processed[1].time).toBe(1623902893182);
+  });
+
+    test('Test implemented processMinerPayments [2]', () => {
+    const miner = 'miner3';
+    const payments = [
+      '{"time":1623901893182,"paid":123.456,"transaction":"bc0b3f953ff408cfb298b034daf5ecd480","miner":"miner1"}',
+      '{"time":1623903893182,"paid":125.456,"transaction":"bc0b5f953ff408cfb298b034daf5ecd480","miner":"miner2"}'];
+    const processed = utils.processMinerPayments(payments, miner);
+    expect(processed.length).toBe(0);
+  });
+
+  test('Test implemented processMinerPayments [3]', () => {
+    const miner = 'miner1';
+    const processed = utils.processMinerPayments(null, miner);
+    expect(processed.length).toBe(0);
   });
 
   test('Test implemented processShares [1]', () => {


### PR DESCRIPTION
This PE extends the API with miner-specific endpoints for /blocks and /payments using ?method=miner_address. This functionality allows to present mined blocks and individual payments for each miner.

Block functionality is simply a new API endpoint but payment functionality required a new Redis sorted set that stores individual payment objects {time, paid, transaction, miner} after transaction is verified from the daemon and transaction hash acquired.