### PR TITLE
Worker/miner share type

### DIFF
--- a/configs/pools/example.js
+++ b/configs/pools/example.js
@@ -63,6 +63,7 @@ config.settings.blockRefreshInterval = 1000;
 config.settings.statisticsRefreshInterval = 20000;
 config.settings.connectionTimeout = 600;
 config.settings.hashrateWindow = 300;
+config.settings.shareTypeWindow = 86400;
 config.settings.jobRebroadcastTimeout = 60;
 config.settings.tcpProxyProtocol = false;
 

--- a/configs/pools/example.js
+++ b/configs/pools/example.js
@@ -63,7 +63,6 @@ config.settings.blockRefreshInterval = 1000;
 config.settings.statisticsRefreshInterval = 20000;
 config.settings.connectionTimeout = 600;
 config.settings.hashrateWindow = 300;
-config.settings.shareTypeWindow = 86400;
 config.settings.jobRebroadcastTimeout = 60;
 config.settings.tcpProxyProtocol = false;
 

--- a/scripts/main/api.js
+++ b/scripts/main/api.js
@@ -150,10 +150,8 @@ const PoolApi = function (client, poolConfigs, portalConfig) {
   this.handleMinersSpecific = function(pool, miner, callback) {
     const algorithm = _this.poolConfigs[pool].primary.coin.algorithms.mining;
     const hashrateWindow = _this.poolConfigs[pool].settings.hashrateWindow;
-    const shareTypeWindow = _this.poolConfigs[pool].settings.shareTypeWindow;
     const multiplier = Math.pow(2, 32) / Algorithms[algorithm].multiplier;
-    const hashrateWindowTime = (((Date.now() / 1000) - hashrateWindow) | 0).toString();
-    const shareTypeWindowTime = (((Date.now() / 1000) - shareTypeWindow) | 0).toString();
+    const windowTime = (((Date.now() / 1000) - hashrateWindow) | 0).toString();
     const commands = [
       ['hgetall', `${ pool }:payments:primary:balances`],
       ['hgetall', `${ pool }:payments:primary:generate`],
@@ -161,61 +159,57 @@ const PoolApi = function (client, poolConfigs, portalConfig) {
       ['hgetall', `${ pool }:payments:primary:paid`],
       ['hgetall', `${ pool }:rounds:primary:current:shared:shares`],
       ['hgetall', `${ pool }:rounds:primary:current:shared:times`],
-      ['zrangebyscore', `${ pool }:rounds:primary:current:shared:hashrate`, hashrateWindowTime, '+inf'],
-      ['zrangebyscore', `${ pool }:rounds:primary:current:shared:hashrate`, shareTypeWindowTime, '+inf'],
+      ['zrangebyscore', `${ pool }:rounds:primary:current:shared:hashrate`, windowTime, '+inf'],
       ['hgetall', `${ pool }:rounds:primary:current:solo:shares`],
-      ['zrangebyscore', `${ pool }:rounds:primary:current:solo:hashrate`, hashrateWindowTime, '+inf'],
-      ['zrangebyscore', `${ pool }:rounds:primary:current:solo:hashrate`, shareTypeWindowTime, '+inf'],
+      ['zrangebyscore', `${ pool }:rounds:primary:current:solo:hashrate`, windowTime, '+inf'],
       ['hgetall', `${ pool }:payments:auxiliary:balances`],
       ['hgetall', `${ pool }:payments:auxiliary:generate`],
       ['hgetall', `${ pool }:payments:auxiliary:immature`],
       ['hgetall', `${ pool }:payments:auxiliary:paid`],
       ['hgetall', `${ pool }:rounds:auxiliary:current:shared:shares`],
       ['hgetall', `${ pool }:rounds:auxiliary:current:shared:times`],
-      ['zrangebyscore', `${ pool }:rounds:auxiliary:current:shared:hashrate`, hashrateWindowTime, '+inf'],
-      ['zrangebyscore', `${ pool }:rounds:auxiliary:current:shared:hashrate`, shareTypeWindowTime, '+inf'],
+      ['zrangebyscore', `${ pool }:rounds:auxiliary:current:shared:hashrate`, windowTime, '+inf'],
       ['hgetall', `${ pool }:rounds:auxiliary:current:solo:shares`],
-      ['zrangebyscore', `${ pool }:rounds:auxiliary:current:solo:hashrate`, hashrateWindowTime, '+inf'],
-      ['zrangebyscore', `${ pool }:rounds:auxiliary:current:solo:hashrate`, shareTypeWindowTime, '+inf']];
+      ['zrangebyscore', `${ pool }:rounds:auxiliary:current:solo:hashrate`, windowTime, '+inf']];
     _this.executeCommands(commands, (results) => {
 
       // Structure Difficulty Data
       const primarySharedShareData = utils.processShares(results[4], miner);
-      const primarySoloShareData = utils.processShares(results[8], miner);
-      const auxiliarySharedShareData = utils.processShares(results[15], miner);
-      const auxiliarySoloShareData = utils.processShares(results[19], miner);
+      const primarySoloShareData = utils.processShares(results[7], miner);
+      const auxiliarySharedShareData = utils.processShares(results[13], miner);
+      const auxiliarySoloShareData = utils.processShares(results[16], miner);
 
       // Structure Times Data
       const primarySharedTimesData = utils.processTimes(results[5], miner);
-      const auxiliarySharedTimesData = utils.processTimes(results[16], miner);
+      const auxiliarySharedTimesData = utils.processTimes(results[14], miner);
 
       // Structure Hashrate Data
       const primarySharedDifficultyData = utils.processDifficulty(results[6], miner, 'miner');
-      const primarySoloDifficultyData = utils.processDifficulty(results[9], miner, 'miner');
-      const auxiliarySharedDifficultyData = utils.processDifficulty(results[17], miner, 'miner');
-      const auxiliarySoloDifficultyData = utils.processDifficulty(results[20], miner, 'miner');
+      const primarySoloDifficultyData = utils.processDifficulty(results[8], miner, 'miner');
+      const auxiliarySharedDifficultyData = utils.processDifficulty(results[15], miner, 'miner');
+      const auxiliarySoloDifficultyData = utils.processDifficulty(results[17], miner, 'miner');
 
       // Structure Payments Data
       const primaryBalanceData = utils.processPayments(results[0], miner)[miner];
       const primaryGenerateData = utils.processPayments(results[1], miner)[miner];
       const primaryImmatureData = utils.processPayments(results[2], miner)[miner];
       const primaryPaidData = utils.processPayments(results[3], miner)[miner];
-      const auxiliaryBalanceData = utils.processPayments(results[11], miner)[miner];
-      const auxiliaryGenerateData = utils.processPayments(results[12], miner)[miner];
-      const auxiliaryImmatureData = utils.processPayments(results[13], miner)[miner];
-      const auxiliaryPaidData = utils.processPayments(results[14], miner)[miner];
+      const auxiliaryBalanceData = utils.processPayments(results[9], miner)[miner];
+      const auxiliaryGenerateData = utils.processPayments(results[10], miner)[miner];
+      const auxiliaryImmatureData = utils.processPayments(results[11], miner)[miner];
+      const auxiliaryPaidData = utils.processPayments(results[12], miner)[miner];
 
       // Structure Share Type Data
-      const primarySharedShareTypeData = utils.processShareTypes(results[7], miner, 'miner');
-      const primarySoloShareTypeData = utils.processShareTypes(results[10], miner, 'miner');
-      const auxiliarySharedShareTypeData = utils.processShareTypes(results[18], miner, 'miner');
-      const auxiliarySoloShareTypeData = utils.processShareTypes(results[21], miner, 'miner');
+      const primarySharedShareTypeData = utils.processShareTypes(results[6], miner, 'miner');
+      const primarySoloShareTypeData = utils.processShareTypes(results[8], miner, 'miner');
+      const auxiliarySharedShareTypeData = utils.processShareTypes(results[15], miner, 'miner');
+      const auxiliarySoloShareTypeData = utils.processShareTypes(results[17], miner, 'miner');
 
       // Structure Worker Type Data
       const primarySharedWorkerData = utils.listWorkers(results[6], miner);
-      const primarySoloWorkerData = utils.listWorkers(results[9], miner);
-      const auxiliarySharedWorkerData = utils.listWorkers(results[17], miner);
-      const auxiliarySoloWorkerData = utils.listWorkers(results[20], miner);
+      const primarySoloWorkerData = utils.listWorkers(results[8], miner);
+      const auxiliarySharedWorkerData = utils.listWorkers(results[15], miner);
+      const auxiliarySoloWorkerData = utils.listWorkers(results[17], miner);
       
       // Build Miner Statistics
       callback(200, {
@@ -638,48 +632,42 @@ const PoolApi = function (client, poolConfigs, portalConfig) {
   this.handleWorkersSpecific = function(pool, worker, callback) {
     const algorithm = _this.poolConfigs[pool].primary.coin.algorithms.mining;
     const hashrateWindow = _this.poolConfigs[pool].settings.hashrateWindow;
-    const shareTypeWindow = _this.poolConfigs[pool].settings.shareTypeWindow;
     const multiplier = Math.pow(2, 32) / Algorithms[algorithm].multiplier;
-    const hashrateWindowTime = (((Date.now() / 1000) - hashrateWindow) | 0).toString();
-    const shareTypeWindowTime = (((Date.now() / 1000) - shareTypeWindow) | 0).toString();
+    const windowTime = (((Date.now() / 1000) - hashrateWindow) | 0).toString();
     const commands = [
       ['hgetall', `${ pool }:rounds:primary:current:shared:shares`],
       ['hgetall', `${ pool }:rounds:primary:current:solo:shares`],
       ['hgetall', `${ pool }:rounds:primary:current:shared:times`],
-      ['zrangebyscore', `${ pool }:rounds:primary:current:shared:hashrate`, hashrateWindowTime, '+inf'],
-      ['zrangebyscore', `${ pool }:rounds:primary:current:solo:hashrate`, hashrateWindowTime, '+inf'],
-      ['zrangebyscore', `${ pool }:rounds:primary:current:shared:hashrate`, shareTypeWindowTime, '+inf'],
-      ['zrangebyscore', `${ pool }:rounds:primary:current:solo:hashrate`, shareTypeWindowTime, '+inf'],
+      ['zrangebyscore', `${ pool }:rounds:primary:current:shared:hashrate`, windowTime, '+inf'],
+      ['zrangebyscore', `${ pool }:rounds:primary:current:solo:hashrate`, windowTime, '+inf'],
       ['hgetall', `${ pool }:rounds:auxiliary:current:shared:shares`],
       ['hgetall', `${ pool }:rounds:auxiliary:current:solo:shares`],
       ['hgetall', `${ pool }:rounds:auxiliary:current:shared:times`],
-      ['zrangebyscore', `${ pool }:rounds:auxiliary:current:shared:hashrate`, hashrateWindowTime, '+inf'],
-      ['zrangebyscore', `${ pool }:rounds:auxiliary:current:solo:hashrate`, hashrateWindowTime, '+inf'],
-      ['zrangebyscore', `${ pool }:rounds:auxiliary:current:shared:hashrate`, shareTypeWindowTime, '+inf'],
-      ['zrangebyscore', `${ pool }:rounds:auxiliary:current:solo:hashrate`, shareTypeWindowTime, '+inf']];
+      ['zrangebyscore', `${ pool }:rounds:auxiliary:current:shared:hashrate`, windowTime, '+inf'],
+      ['zrangebyscore', `${ pool }:rounds:auxiliary:current:solo:hashrate`, windowTime, '+inf']];
     _this.executeCommands(commands, (results) => {
 
       // Structure Difficulty Data
       const primarySharedShareData = utils.processShares(results[0], worker);
       const primarySoloShareData = utils.processShares(results[1], worker);
-      const auxiliarySharedShareData = utils.processShares(results[7], worker);
-      const auxiliarySoloShareData = utils.processShares(results[8], worker);
+      const auxiliarySharedShareData = utils.processShares(results[5], worker);
+      const auxiliarySoloShareData = utils.processShares(results[6], worker);
 
       // Structure Times Data
       const primarySharedTimesData = utils.processTimes(results[2], worker);
-      const auxiliarySharedTimesData = utils.processTimes(results[9], worker);
+      const auxiliarySharedTimesData = utils.processTimes(results[7], worker);
 
       // Structure Hashrate Data
       const primarySharedDifficultyData = utils.processDifficulty(results[3], worker, 'worker');
       const primarySoloDifficultyData = utils.processDifficulty(results[4], worker, 'worker');
-      const auxiliarySharedDifficultyData = utils.processDifficulty(results[10], worker, 'worker');
-      const auxiliarySoloDifficultyData = utils.processDifficulty(results[11], worker, 'worker');
+      const auxiliarySharedDifficultyData = utils.processDifficulty(results[8], worker, 'worker');
+      const auxiliarySoloDifficultyData = utils.processDifficulty(results[9], worker, 'worker');
 
       // Structure Share Type Data
-      const primarySharedShareTypeData = utils.processShareTypes(results[5], worker, 'worker');
-      const primarySoloShareTypeData = utils.processShareTypes(results[6], worker, 'worker');
-      const auxiliarySharedShareTypeData = utils.processShareTypes(results[12], worker, 'worker');
-      const auxiliarySoloShareTypeData = utils.processShareTypes(results[13], worker, 'worker');
+      const primarySharedShareTypeData = utils.processShareTypes(results[3], worker, 'worker');
+      const primarySoloShareTypeData = utils.processShareTypes(results[4], worker, 'worker');
+      const auxiliarySharedShareTypeData = utils.processShareTypes(results[8], worker, 'worker');
+      const auxiliarySoloShareTypeData = utils.processShareTypes(results[9], worker, 'worker');
 
       // Build Worker Statistics
       callback(200, {

--- a/scripts/main/api.js
+++ b/scripts/main/api.js
@@ -697,7 +697,6 @@ const PoolApi = function (client, poolConfigs, portalConfig) {
             shared: primarySharedShareTypeData,
             solo: primarySoloShareTypeData,
           },
-          test: utils.newProcessWorkers(results[0], results[1], results[2], results[3], results[4], results[5], results[6], multiplier, hashrateWindow, shareTypeWindow, true),
         },
         auxiliary: {
           difficulty: {

--- a/scripts/main/payments.js
+++ b/scripts/main/payments.js
@@ -544,18 +544,18 @@ const PoolPayments = function (logger, client) {
         Object.keys(round || {}).forEach((entry) => {
           const details = JSON.parse(round[entry]);
           const address = entry.split('.')[0];
-          const shareValue = /^-?\d*(\.\d+)?$/.test(details.difficulty) ? parseFloat(details.difficulty) : 0;
+          const difficultyValue = /^-?\d*(\.\d+)?$/.test(details.difficulty) ? parseFloat(details.difficulty) : 0;
           if (details.solo) {
             if (address in soloRound) {
-              soloRound[address] += parseFloat(shareValue);
+              soloRound[address] += parseFloat(difficultyValue);
             } else {
-              soloRound[address] = parseFloat(shareValue);
+              soloRound[address] = parseFloat(difficultyValue);
             }
           } else {
             if (address in sharedRound) {
-              sharedRound[address] += parseFloat(shareValue);
+              sharedRound[address] += parseFloat(difficultyValue);
             } else {
-              sharedRound[address] = parseFloat(shareValue);
+              sharedRound[address] = parseFloat(difficultyValue);
             }
           }
         });

--- a/scripts/main/shares.js
+++ b/scripts/main/shares.js
@@ -104,11 +104,11 @@ const PoolShares = function (logger, client, poolConfig, portalConfig) {
     const lastShare = JSON.parse(shares[worker] || '{}');
     Object.keys(shares).forEach((share) => {
       const shareInfo = JSON.parse(shares[share]);
-      const shareValue = /^-?\d*(\.\d+)?$/.test(shareInfo.difficulty) ? parseFloat(shareInfo.difficulty) : 0;
+      const difficultyValue = /^-?\d*(\.\d+)?$/.test(shareInfo.difficulty) ? parseFloat(shareInfo.difficulty) : 0;
       if (isSoloMining && share === worker && shareInfo.solo) {
-        difficulties += shareValue;
+        difficulties += difficultyValue;
       } else if (!isSoloMining && !shareInfo.solo) {
-        difficulties += shareValue;
+        difficulties += difficultyValue;
       }
     });
 
@@ -138,6 +138,7 @@ const PoolShares = function (logger, client, poolConfig, portalConfig) {
     // Build Secondary Output (Solo)
     const hashrateShare = JSON.parse(JSON.stringify(outputShare));
     hashrateShare.difficulty = difficulty;
+    hashrateShare.type = shareType;
 
     // No Shared Effort if Solo Share
     if (shareType === 'valid' && isSoloMining) {
@@ -192,11 +193,11 @@ const PoolShares = function (logger, client, poolConfig, portalConfig) {
     const lastShare = JSON.parse(shares[worker] || '{}');
     Object.keys(shares).forEach((share) => {
       const shareInfo = JSON.parse(shares[share]);
-      const shareValue = /^-?\d*(\.\d+)?$/.test(shareInfo.difficulty) ? parseFloat(shareInfo.difficulty) : 0;
+      const difficultyValue = /^-?\d*(\.\d+)?$/.test(shareInfo.difficulty) ? parseFloat(shareInfo.difficulty) : 0;
       if (isSoloMining && share === worker && shareInfo.solo) {
-        difficulties += shareValue;
+        difficulties += difficultyValue;
       } else if (!isSoloMining && !shareInfo.solo) {
-        difficulties += shareValue;
+        difficulties += difficultyValue;
       }
     });
 

--- a/scripts/main/utils.js
+++ b/scripts/main/utils.js
@@ -402,34 +402,6 @@ exports.processWorkers = function(shares, hashrate, times, multiplier, hashrateW
   return Object.values(workers);
 };
 
-// Process Workers for API Endpoints
-exports.newProcessWorkers = function(sharedShares, soloShares, times, sharedHashrate, soloHashrate, sharedTypes, soloTypes, multiplier, hashrateWindow, shareTypeWindow, active) {
-  const workers = {};
-  if (shares) {
-    Object.keys(shares).forEach((entry) => {
-      const details = JSON.parse(shares[entry]);
-      const difficultyValue = /^-?\d*(\.\d+)?$/.test(details.difficulty) ? parseFloat(details.difficulty) : 0;
-      const effortValue = (!times) ? (/^-?\d*(\.\d+)?$/.test(details.effort) ? parseFloat(details.effort) : 0) : null;
-      const timeValue = (times) ? (/^-?\d*(\.\d+)?$/.test(times[entry]) ? parseFloat(times[entry]) : 0) : null;
-      const hashrateValue = exports.processDifficulty(hashrate, entry, 'worker');
-      const shareTypeCounts = exports.processShareTypes(hashrate, entry, 'worker');
-      if (details.worker && difficultyValue > 0) {
-        if (!active || (active && hashrateValue > 0)) {
-          workers[entry] = {
-            worker: entry,
-            difficulty: difficultyValue,
-            times: timeValue || null,
-            hashrate: (multiplier * hashrateValue) / hashrateWindow,
-            effort: effortValue || null,
-            shares: shareTypeCounts,
-          };
-        }
-      }
-    });
-  }
-  return Object.values(workers);
-};
-
 // Round to # of Digits Given
 exports.roundTo = function(n, digits) {
   if (!digits) {

--- a/scripts/main/utils.js
+++ b/scripts/main/utils.js
@@ -212,13 +212,15 @@ exports.listBlocks = function(blocks, miner) {
 exports.processDifficulty = function(shares, miner, type) {
   let count = 0;
   if (shares) {
-    shares = shares.map((share) => JSON.parse(share));
+    shares = shares
+      .map((share) => JSON.parse(share))
+      .filter((share) => share.type === 'valid');
     shares.forEach((share) => {
       if (share.worker && share.difficulty) {
         const address = share.worker.split('.')[0];
-        const shareValue = /^-?\d*(\.\d+)?$/.test(share.difficulty) ? parseFloat(share.difficulty) : 0;
+        const difficultyValue = /^-?\d*(\.\d+)?$/.test(share.difficulty) ? parseFloat(share.difficulty) : 0;
         if (!miner || miner === share.worker || (type === 'miner' && miner === address)) {
-          count += shareValue;
+          count += difficultyValue;
         }
       }
     });
@@ -247,13 +249,14 @@ exports.processMiners = function(shares, hashrate, times, multiplier, hashrateWi
     Object.keys(shares).forEach((entry) => {
       const details = JSON.parse(shares[entry]);
       const address = entry.split('.')[0];
-      const shareValue = /^-?\d*(\.\d+)?$/.test(details.difficulty) ? parseFloat(details.difficulty) : 0;
+      const difficultyValue = /^-?\d*(\.\d+)?$/.test(details.difficulty) ? parseFloat(details.difficulty) : 0;
       const effortValue = (!times) ? (/^-?\d*(\.\d+)?$/.test(details.effort) ? parseFloat(details.effort) : 0) : null;
       const timeValue = (times) ? (/^-?\d*(\.\d+)?$/.test(times[entry]) ? parseFloat(times[entry]) : 0) : null;
       const hashrateValue = exports.processDifficulty(hashrate, address, 'miner');
-      if (details.worker && shareValue > 0) {
+      const shareTypeCounts = exports.processShareTypes(hashrate, address, 'miner');
+      if (details.worker && difficultyValue > 0) {
         if (address in miners) {
-          miners[address].shares += shareValue;
+          miners[address].difficulty += difficultyValue;
           if (times && timeValue >= miners[address].times) {
             miners[address].times = timeValue;
           } else if (!times) {
@@ -263,10 +266,11 @@ exports.processMiners = function(shares, hashrate, times, multiplier, hashrateWi
           if (!active || (active && hashrateValue > 0)) {
             miners[address] = {
               miner: address,
-              shares: shareValue,
+              difficulty: difficultyValue,
               times: timeValue || null,
               hashrate: (multiplier * hashrateValue) / hashrateWindow,
               effort: effortValue || null,
+              shares: shareTypeCounts,
             };
           }
         }
@@ -306,19 +310,44 @@ exports.processShares = function(shares, miner) {
     Object.keys(shares).forEach((entry) => {
       const details = JSON.parse(shares[entry]);
       const address = (miner && miner.includes('.')) ? entry : entry.split('.')[0];
-      const shareValue = /^-?\d*(\.\d+)?$/.test(details.difficulty) ? parseFloat(details.difficulty) : 0;
+      const difficultyValue = /^-?\d*(\.\d+)?$/.test(details.difficulty) ? parseFloat(details.difficulty) : 0;
       if (!miner || miner === address) {
-        if (shareValue > 0) {
+        if (difficultyValue > 0) {
           if (address in output) {
-            output[address] += shareValue;
+            output[address] += difficultyValue;
           } else {
-            output[address] = shareValue;
+            output[address] = difficultyValue;
           }
         }
       }
     });
   }
   return output;
+};
+
+// Process Share Types for API Endpoints
+exports.processShareTypes = function(shares, miner, type) {
+  let shareTypes = {
+    valid: 0,
+    stale: 0,
+    invalid: 0,
+  };
+
+  if (shares) {
+    shares = shares
+      .map((share) => JSON.parse(share));
+    shares.forEach((share) => {
+      if (share.worker && share.type) {
+        const address = share.worker.split('.')[0];
+        if (!miner || miner === share.worker || (type === 'miner' && miner === address)) {
+          if (share.type === 'valid') shareTypes.valid += 1
+          else if (share.type === 'stale')  shareTypes.stale += 1
+          else if (share.type === 'invalid')  shareTypes.invalid += 1
+        }
+      }
+    });
+  }
+  return shareTypes;
 };
 
 // Process Times for API Endpoints
@@ -351,18 +380,48 @@ exports.processWorkers = function(shares, hashrate, times, multiplier, hashrateW
   if (shares) {
     Object.keys(shares).forEach((entry) => {
       const details = JSON.parse(shares[entry]);
-      const shareValue = /^-?\d*(\.\d+)?$/.test(details.difficulty) ? parseFloat(details.difficulty) : 0;
+      const difficultyValue = /^-?\d*(\.\d+)?$/.test(details.difficulty) ? parseFloat(details.difficulty) : 0;
       const effortValue = (!times) ? (/^-?\d*(\.\d+)?$/.test(details.effort) ? parseFloat(details.effort) : 0) : null;
       const timeValue = (times) ? (/^-?\d*(\.\d+)?$/.test(times[entry]) ? parseFloat(times[entry]) : 0) : null;
       const hashrateValue = exports.processDifficulty(hashrate, entry, 'worker');
-      if (details.worker && shareValue > 0) {
+      const shareTypeCounts = exports.processShareTypes(hashrate, entry, 'worker');
+      if (details.worker && difficultyValue > 0) {
         if (!active || (active && hashrateValue > 0)) {
           workers[entry] = {
             worker: entry,
-            shares: shareValue,
+            difficulty: difficultyValue,
             times: timeValue || null,
             hashrate: (multiplier * hashrateValue) / hashrateWindow,
             effort: effortValue || null,
+            shares: shareTypeCounts,
+          };
+        }
+      }
+    });
+  }
+  return Object.values(workers);
+};
+
+// Process Workers for API Endpoints
+exports.newProcessWorkers = function(sharedShares, soloShares, times, sharedHashrate, soloHashrate, sharedTypes, soloTypes, multiplier, hashrateWindow, shareTypeWindow, active) {
+  const workers = {};
+  if (shares) {
+    Object.keys(shares).forEach((entry) => {
+      const details = JSON.parse(shares[entry]);
+      const difficultyValue = /^-?\d*(\.\d+)?$/.test(details.difficulty) ? parseFloat(details.difficulty) : 0;
+      const effortValue = (!times) ? (/^-?\d*(\.\d+)?$/.test(details.effort) ? parseFloat(details.effort) : 0) : null;
+      const timeValue = (times) ? (/^-?\d*(\.\d+)?$/.test(times[entry]) ? parseFloat(times[entry]) : 0) : null;
+      const hashrateValue = exports.processDifficulty(hashrate, entry, 'worker');
+      const shareTypeCounts = exports.processShareTypes(hashrate, entry, 'worker');
+      if (details.worker && difficultyValue > 0) {
+        if (!active || (active && hashrateValue > 0)) {
+          workers[entry] = {
+            worker: entry,
+            difficulty: difficultyValue,
+            times: timeValue || null,
+            hashrate: (multiplier * hashrateValue) / hashrateWindow,
+            effort: effortValue || null,
+            shares: shareTypeCounts,
           };
         }
       }

--- a/scripts/test/api.test.js
+++ b/scripts/test/api.test.js
@@ -324,10 +324,12 @@ describe('Test API functionality', () => {
       ['hset', 'Pool1:rounds:primary:current:shared:shares', 'worker2.w2', JSON.stringify({ time: 0, difficulty: 44, worker: 'worker2.w2' })],
       ['hset', 'Pool1:rounds:primary:current:shared:shares', 'worker3', JSON.stringify({ time: 0, difficulty: 8, worker: 'worker3' })],
       ['hincrbyfloat', 'Pool1:rounds:primary:current:times', 'worker1', 20.15],
-      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', difficulty: 32 })],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', difficulty: 64 })],
-      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', difficulty: 32 })],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker2.w2', difficulty: 44 })]];
+      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', difficulty: 32, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', difficulty: 64, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', difficulty: 32, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', difficulty: 32, type: 'stale' })],
+      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', difficulty: 32, type: 'invalid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker2.w2', difficulty: 44, type: 'valid' })]];
     const response = mockResponse();
     response.on('end', (payload) => {
       const processed = JSON.parse(payload);
@@ -336,11 +338,14 @@ describe('Test API functionality', () => {
       expect(processed.body.primary.shared.length).toBe(1);
       expect(processed.body.primary.solo.length).toBe(1);
       expect(processed.body.primary.shared[0].miner).toBe('worker2');
-      expect(processed.body.primary.shared[0].shares).toBe(108);
+      expect(processed.body.primary.shared[0].difficulty).toBe(108);
       expect(processed.body.primary.shared[0].hashrate).toBe(1546188226.56);
       expect(processed.body.primary.solo[0].miner).toBe('worker1');
-      expect(processed.body.primary.solo[0].shares).toBe(64);
+      expect(processed.body.primary.solo[0].difficulty).toBe(64);
       expect(processed.body.primary.solo[0].hashrate).toBe(916259689.8133334);
+      expect(processed.body.primary.solo[0].shares.valid).toBe(2);
+      expect(processed.body.primary.solo[0].shares.stale).toBe(1);
+      expect(processed.body.primary.solo[0].shares.invalid).toBe(1);
       done();
     });
     mockSetupClient(client, commands, 'Pool1', () => {
@@ -370,26 +375,34 @@ describe('Test API functionality', () => {
       ['hset', 'Pool1:rounds:primary:current:shared:shares', 'worker2.w2', JSON.stringify({ time: 0, difficulty: 44, worker: 'worker2.w2' })],
       ['hset', 'Pool1:rounds:primary:current:shared:shares', 'worker3', JSON.stringify({ time: 0, difficulty: 8, worker: 'worker3' })],
       ['hincrbyfloat', 'Pool1:rounds:primary:current:times', 'worker1', 20.15],
-      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', difficulty: 32 })],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', difficulty: 64 })],
-      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', difficulty: 32 })],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker3', difficulty: 8 })],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker2.w2', difficulty: 44 })]];
+      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', difficulty: 32, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', difficulty: 64, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', difficulty: 64, type: 'stale' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', difficulty: 64, type: 'invalid' })],
+      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', difficulty: 32, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker3', difficulty: 8, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker2.w2', difficulty: 44, type: 'valid' })]];
     const response = mockResponse();
     response.on('end', (payload) => {
       const processed = JSON.parse(payload);
       expect(processed.statusCode).toBe(200);
       expect(typeof processed.body).toBe('object');
-      expect(Object.keys(processed.body.primary).length).toBe(4);
-      expect(Object.keys(processed.body.auxiliary).length).toBe(4);
-      expect(processed.body.primary.current.shared).toBe(108);
-      expect(processed.body.primary.current.solo).toBe(0);
-      expect(processed.body.primary.current.times).toBe(0);
+      expect(Object.keys(processed.body.primary).length).toBe(6);
+      expect(Object.keys(processed.body.auxiliary).length).toBe(6);
+      expect(processed.body.primary.difficulty.shared).toBe(108);
+      expect(processed.body.primary.difficulty.solo).toBe(0);
+      expect(processed.body.primary.times).toBe(0);
       expect(processed.body.primary.payments.balances).toBe(37.43);
       expect(processed.body.primary.payments.generate).toBe(255.17);
       expect(processed.body.primary.payments.immature).toBe(12.17);
       expect(processed.body.primary.payments.paid).toBe(123.5);
       expect(processed.body.primary.hashrate.shared).toBe(1546188226.56);
+      expect(processed.body.primary.shares.shared.valid).toBe(2);
+      expect(processed.body.primary.shares.shared.stale).toBe(1);
+      expect(processed.body.primary.shares.shared.invalid).toBe(1);
+      expect(processed.body.primary.shares.solo.valid).toBe(0);
+      expect(processed.body.primary.shares.solo.stale).toBe(0);
+      expect(processed.body.primary.shares.solo.invalid).toBe(0);
       expect(processed.body.primary.workers.shared.length).toBe(2);
       expect(processed.body.primary.workers.shared[0]).toBe('worker2.w1');
       expect(processed.body.primary.workers.shared[1]).toBe('worker2.w2');
@@ -418,25 +431,30 @@ describe('Test API functionality', () => {
       ['hset', 'Pool1:rounds:auxiliary:current:shared:shares', 'worker2.w2', JSON.stringify({ time: 0, difficulty: 44, solo: false, worker: 'worker2.w2' })],
       ['hset', 'Pool1:rounds:auxiliary:current:shared:shares', 'worker3', JSON.stringify({ time: 0, difficulty: 8, solo: false, worker: 'worker3' })],
       ['hincrbyfloat', 'Pool1:rounds:auxiliary:current:shared:times', 'worker1', 20.15],
-      ['zadd', 'Pool1:rounds:auxiliary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', difficulty: 32 })],
-      ['zadd', 'Pool1:rounds:auxiliary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', difficulty: 64 })],
-      ['zadd', 'Pool1:rounds:auxiliary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', difficulty: 32 })],
-      ['zadd', 'Pool1:rounds:auxiliary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker3', difficulty: 8 })],
-      ['zadd', 'Pool1:rounds:auxiliary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker2.w2', difficulty: 44 })]];
+      ['zadd', 'Pool1:rounds:auxiliary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', difficulty: 32, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:auxiliary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', difficulty: 32, type: 'stale' })],
+      ['zadd', 'Pool1:rounds:auxiliary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', difficulty: 32, type: 'invalid' })],
+      ['zadd', 'Pool1:rounds:auxiliary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', difficulty: 64, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:auxiliary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', difficulty: 32, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:auxiliary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker3', difficulty: 8, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:auxiliary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker2.w2', difficulty: 44, type: 'valid' })]];
     const response = mockResponse();
     response.on('end', (payload) => {
       const processed = JSON.parse(payload);
       expect(processed.statusCode).toBe(200);
       expect(typeof processed.body).toBe('object');
-      expect(Object.keys(processed.body.primary).length).toBe(4);
-      expect(Object.keys(processed.body.auxiliary).length).toBe(4);
-      expect(processed.body.auxiliary.current.shared).toBe(0);
-      expect(processed.body.auxiliary.current.solo).toBe(64);
-      expect(processed.body.auxiliary.current.times).toBe(20.15);
+      expect(Object.keys(processed.body.primary).length).toBe(6);
+      expect(Object.keys(processed.body.auxiliary).length).toBe(6);
+      expect(processed.body.auxiliary.difficulty.shared).toBe(0);
+      expect(processed.body.auxiliary.difficulty.solo).toBe(64);
+      expect(processed.body.auxiliary.times).toBe(20.15);
       expect(processed.body.auxiliary.payments.generate).toBe(0);
       expect(processed.body.auxiliary.payments.immature).toBe(0);
       expect(processed.body.auxiliary.payments.paid).toBe(0);
       expect(processed.body.auxiliary.hashrate.solo).toBe(916259689.8133334);
+      expect(processed.body.auxiliary.shares.solo.valid).toBe(2);
+      expect(processed.body.auxiliary.shares.solo.stale).toBe(1);
+      expect(processed.body.auxiliary.shares.solo.invalid).toBe(1);
       expect(processed.body.auxiliary.workers.solo.length).toBe(1);
       expect(processed.body.auxiliary.workers.solo[0]).toBe('worker1');
       done();
@@ -457,11 +475,11 @@ describe('Test API functionality', () => {
       ['hset', 'Pool1:rounds:primary:current:shared:shares', 'worker2.w2', JSON.stringify({ time: 0, difficulty: 44, worker: 'worker2.w2' })],
       ['hset', 'Pool1:rounds:primary:current:shared:shares', 'worker3', JSON.stringify({ time: 0, difficulty: 8, worker: 'worker3' })],
       ['hincrbyfloat', 'Pool1:rounds:primary:current:times', 'worker1', 20.15],
-      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', difficulty: 32 })],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', difficulty: 64 })],
-      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', difficulty: 32 })],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker3', difficulty: 8 })],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker2.w2', difficulty: 44 })]];
+      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', difficulty: 32, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', difficulty: 64, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', difficulty: 32, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker3', difficulty: 8, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker2.w2', difficulty: 44, type: 'valid' })]];
     const response = mockResponse();
     response.on('end', (payload) => {
       const processed = JSON.parse(payload);
@@ -470,13 +488,13 @@ describe('Test API functionality', () => {
       expect(processed.body.primary.shared.length).toBe(2);
       expect(processed.body.primary.solo.length).toBe(1);
       expect(processed.body.primary.shared[0].miner).toBe('worker2');
-      expect(processed.body.primary.shared[0].shares).toBe(108);
+      expect(processed.body.primary.shared[0].difficulty).toBe(108);
       expect(processed.body.primary.shared[0].hashrate).toBe(1546188226.56);
       expect(processed.body.primary.shared[1].miner).toBe('worker3');
-      expect(processed.body.primary.shared[1].shares).toBe(8);
+      expect(processed.body.primary.shared[1].difficulty).toBe(8);
       expect(processed.body.primary.shared[1].hashrate).toBe(114532461.22666667);
       expect(processed.body.primary.solo[0].miner).toBe('worker1');
-      expect(processed.body.primary.solo[0].shares).toBe(64);
+      expect(processed.body.primary.solo[0].difficulty).toBe(64);
       expect(processed.body.primary.solo[0].hashrate).toBe(916259689.8133334);
       done();
     });
@@ -823,16 +841,16 @@ describe('Test API functionality', () => {
       ['hset', 'Pool1:rounds:primary:current:shared:counts', 'valid', 3190],
       ['hset', 'Pool1:rounds:primary:current:shared:counts', 'stale', 123],
       ['hset', 'Pool1:rounds:primary:current:shared:counts', 'invalid', 465],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', solo: true, difficulty: 32 })],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', solo: false, difficulty: 64 })],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', solo: true, difficulty: 32 })],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker3', solo: false, difficulty: 8 })],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker2.w2', solo: false, difficulty: 44 })],
-      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', solo: true, difficulty: 32 })],
-      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', solo: false, difficulty: 64 })],
-      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', solo: true, difficulty: 32 })],
-      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker3', solo: false, difficulty: 8 })],
-      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker2.w2', solo: false, difficulty: 44 })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', solo: true, difficulty: 32, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', solo: false, difficulty: 64, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', solo: true, difficulty: 32, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker3', solo: false, difficulty: 8, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker2.w2', solo: false, difficulty: 44, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', solo: true, difficulty: 32, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', solo: false, difficulty: 64, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', solo: true, difficulty: 32, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker3', solo: false, difficulty: 8, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker2.w2', solo: false, difficulty: 44, type: 'valid' })],
       ['hset', 'Pool1:blocks:auxiliary:counts', 'valid', 500],
       ['hset', 'Pool1:blocks:auxiliary:counts', 'invalid', 2]];
     const response = mockResponse();
@@ -876,16 +894,16 @@ describe('Test API functionality', () => {
       ['hset', 'Pool1:rounds:primary:current:shared:counts', 'valid', 3190],
       ['hset', 'Pool1:rounds:primary:current:shared:counts', 'stale', 123],
       ['hset', 'Pool1:rounds:primary:current:shared:counts', 'invalid', 465],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', solo: true, difficulty: 32 })],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', solo: false, difficulty: 64 })],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', solo: true, difficulty: 32 })],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker3', solo: false, difficulty: 8 })],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker2.w2', solo: false, difficulty: 44 })],
-      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', solo: true, difficulty: 32 })],
-      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', solo: false, difficulty: 64 })],
-      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', solo: true, difficulty: 32 })],
-      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker3', solo: false, difficulty: 8 })],
-      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker2.w2', solo: false, difficulty: 44 })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', solo: true, difficulty: 32, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', solo: false, difficulty: 64, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', solo: true, difficulty: 32, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker3', solo: false, difficulty: 8, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker2.w2', solo: false, difficulty: 44, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', solo: true, difficulty: 32, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', solo: false, difficulty: 64, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', solo: true, difficulty: 32, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker3', solo: false, difficulty: 8, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker2.w2', solo: false, difficulty: 44, type: 'valid' })],
       ['hset', 'Pool1:blocks:auxiliary:counts', 'valid', 500],
       ['hset', 'Pool1:blocks:auxiliary:counts', 'invalid', 2]];
     const response = mockResponse();
@@ -924,10 +942,12 @@ describe('Test API functionality', () => {
       ['hset', 'Pool1:rounds:primary:current:shared:shares', 'worker2.w2', JSON.stringify({ time: 0, difficulty: 44, worker: 'worker2.w2' })],
       ['hset', 'Pool1:rounds:primary:current:shared:shares', 'worker3', JSON.stringify({ time: 0, difficulty: 8, worker: 'worker3' })],
       ['hincrbyfloat', 'Pool1:rounds:primary:current:times', 'worker1', 20.15],
-      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', difficulty: 32 })],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', difficulty: 64 })],
-      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', difficulty: 32 })],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker2.w2', difficulty: 44 })]];
+      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', difficulty: 32, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', difficulty: 32, type: 'stale' })],
+      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', difficulty: 32, type: 'invalid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', difficulty: 64, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', difficulty: 32, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker2.w2', difficulty: 44, type: 'valid' })]];
     const response = mockResponse();
     response.on('end', (payload) => {
       const processed = JSON.parse(payload);
@@ -936,14 +956,20 @@ describe('Test API functionality', () => {
       expect(processed.body.primary.shared.length).toBe(2);
       expect(processed.body.primary.solo.length).toBe(1);
       expect(processed.body.primary.shared[0].worker).toBe('worker2.w1');
-      expect(processed.body.primary.shared[0].shares).toBe(64);
+      expect(processed.body.primary.shared[0].difficulty).toBe(64);
       expect(processed.body.primary.shared[0].hashrate).toBe(916259689.8133334);
+      expect(processed.body.primary.shared[0].shares.valid).toBe(1);
+      expect(processed.body.primary.shared[0].shares.stale).toBe(0);
+      expect(processed.body.primary.shared[0].shares.invalid).toBe(0);
       expect(processed.body.primary.shared[1].worker).toBe('worker2.w2');
-      expect(processed.body.primary.shared[1].shares).toBe(44);
+      expect(processed.body.primary.shared[1].difficulty).toBe(44);
       expect(processed.body.primary.shared[1].hashrate).toBe(629928536.7466667);
       expect(processed.body.primary.solo[0].worker).toBe('worker1');
-      expect(processed.body.primary.solo[0].shares).toBe(64);
+      expect(processed.body.primary.solo[0].difficulty).toBe(64);
       expect(processed.body.primary.solo[0].hashrate).toBe(916259689.8133334);
+      expect(processed.body.primary.solo[0].shares.valid).toBe(2);
+      expect(processed.body.primary.solo[0].shares.stale).toBe(1);
+      expect(processed.body.primary.solo[0].shares.invalid).toBe(1);
       done();
     });
     mockSetupClient(client, commands, 'Pool1', () => {
@@ -971,22 +997,35 @@ describe('Test API functionality', () => {
       ['hset', 'Pool1:rounds:primary:current:shared:shares', 'worker3', JSON.stringify({ time: 1, difficulty: 8, worker: 'worker3', solo: false })],
       ['hset', 'Pool1:rounds:primary:current:shared:shares', 'worker2.w2', JSON.stringify({ time: 1, difficulty: 44, worker: 'worker2.w2', solo: false })],
       ['hset', 'Pool1:rounds:primary:current:shared:times', 'worker1', 20.15],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', solo: true, difficulty: 32 })],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', solo: false, difficulty: 64 })],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', solo: true, difficulty: 32 })],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker3', solo: false, difficulty: 8 })],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker2.w2', solo: false, difficulty: 44 })]];
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', solo: true, difficulty: 32, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', solo: false, difficulty: 64, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', solo: false, difficulty: 64, type: 'stale' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', solo: false, difficulty: 64, type: 'invalid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', solo: true, difficulty: 32, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker3', solo: false, difficulty: 8, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker2.w2', solo: false, difficulty: 8, type: 'stale' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker2.w2', solo: false, difficulty: 8, type: 'invalid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker2.w2', solo: false, difficulty: 44, type: 'valid' })]];
     const response = mockResponse();
     response.on('end', (payload) => {
       const processed = JSON.parse(payload);
       expect(processed.statusCode).toBe(200);
       expect(typeof processed.body).toBe('object');
-      expect(Object.keys(processed.body.primary).length).toBe(2);
-      expect(Object.keys(processed.body.auxiliary).length).toBe(2);
-      expect(processed.body.primary.current.shared).toBe(64);
-      expect(processed.body.primary.current.solo).toBe(0);
-      expect(processed.body.primary.current.times).toBe(0);
+      expect(Object.keys(processed.body.primary).length).toBe(4);
+      expect(Object.keys(processed.body.auxiliary).length).toBe(4);
+      expect(processed.body.primary.difficulty.shared).toBe(64);
+      expect(processed.body.primary.difficulty.solo).toBe(0);
+      expect(processed.body.primary.times).toBe(0);
       expect(processed.body.primary.hashrate.shared).toBe(916259689.8133334);
+      expect(processed.body.primary.hashrate.solo).toBe(0);
+      expect(processed.body.primary.shares.shared.valid).toBe(1);
+      expect(processed.body.primary.shares.shared.stale).toBe(1);
+      expect(processed.body.primary.shares.shared.invalid).toBe(1);
+      expect(processed.body.primary.shares.solo.valid).toBe(0);
+      expect(processed.body.primary.shares.solo.stale).toBe(0);
+      expect(processed.body.primary.shares.solo.invalid).toBe(0);
+      
+      
       done();
     });
     mockSetupClient(client, commands, 'Pool1', () => {
@@ -1011,21 +1050,31 @@ describe('Test API functionality', () => {
       ['hset', 'Pool1:rounds:auxiliary:current:solo:shares', 'worker2.w1', JSON.stringify({ time: 0, difficulty: 64, worker: 'worker2.w1', solo: false })],
       ['hset', 'Pool1:rounds:auxiliary:current:solo:shares', 'worker3', JSON.stringify({ time: 1, difficulty: 8, worker: 'worker3', solo: false })],
       ['hset', 'Pool1:rounds:auxiliary:current:solo:shares', 'worker2.w2', JSON.stringify({ time: 1, difficulty: 44, worker: 'worker2.w2', solo: false })],
-      ['zadd', 'Pool1:rounds:auxiliary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', solo: true, difficulty: 32 })],
-      ['zadd', 'Pool1:rounds:auxiliary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', solo: false, difficulty: 64 })],
-      ['zadd', 'Pool1:rounds:auxiliary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', solo: true, difficulty: 32 })],
-      ['zadd', 'Pool1:rounds:auxiliary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker3', solo: false, difficulty: 8 })],
-      ['zadd', 'Pool1:rounds:auxiliary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker2.w2', solo: false, difficulty: 44 })]];
+      ['zadd', 'Pool1:rounds:auxiliary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', solo: true, difficulty: 32, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:auxiliary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', solo: false, difficulty: 64, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:auxiliary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', solo: true, difficulty: 32, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:auxiliary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', solo: false, difficulty: 8, type: 'stale' })],
+      ['zadd', 'Pool1:rounds:auxiliary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', solo: false, difficulty: 8, type: 'invalid' })],
+      ['zadd', 'Pool1:rounds:auxiliary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker3', solo: false, difficulty: 8, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:auxiliary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker2.w2', solo: false, difficulty: 44, type: 'valid' })]];
     const response = mockResponse();
     response.on('end', (payload) => {
       const processed = JSON.parse(payload);
       expect(processed.statusCode).toBe(200);
       expect(typeof processed.body).toBe('object');
-      expect(Object.keys(processed.body.primary).length).toBe(2);
-      expect(Object.keys(processed.body.auxiliary).length).toBe(2);
-      expect(processed.body.auxiliary.current.shared).toBe(0);
-      expect(processed.body.auxiliary.current.solo).toBe(64);
+      expect(Object.keys(processed.body.primary).length).toBe(4);
+      expect(Object.keys(processed.body.auxiliary).length).toBe(4);
+      expect(processed.body.auxiliary.difficulty.shared).toBe(0);
+      expect(processed.body.auxiliary.difficulty.solo).toBe(64);
+      expect(processed.body.auxiliary.times).toBe(0);
+      expect(processed.body.auxiliary.hashrate.shared).toBe(0);
       expect(processed.body.auxiliary.hashrate.solo).toBe(916259689.8133334);
+      expect(processed.body.auxiliary.shares.shared.valid).toBe(0);
+      expect(processed.body.auxiliary.shares.shared.stale).toBe(0);
+      expect(processed.body.auxiliary.shares.shared.invalid).toBe(0);
+      expect(processed.body.auxiliary.shares.solo.valid).toBe(2);
+      expect(processed.body.auxiliary.shares.solo.stale).toBe(1);
+      expect(processed.body.auxiliary.shares.solo.invalid).toBe(1);
       done();
     });
     mockSetupClient(client, commands, 'Pool1', () => {
@@ -1044,11 +1093,13 @@ describe('Test API functionality', () => {
       ['hset', 'Pool1:rounds:primary:current:shared:shares', 'worker2.w2', JSON.stringify({ time: 0, difficulty: 44, worker: 'worker2.w2' })],
       ['hset', 'Pool1:rounds:primary:current:shared:shares', 'worker3', JSON.stringify({ time: 0, difficulty: 8, worker: 'worker3' })],
       ['hincrbyfloat', 'Pool1:rounds:primary:current:times', 'worker1', 20.15],
-      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', difficulty: 32 })],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', difficulty: 64 })],
-      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', difficulty: 32 })],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker3', difficulty: 8 })],
-      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker2.w2', difficulty: 44 })]];
+      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker1', difficulty: 32, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', difficulty: 64, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 0, worker: 'worker2.w1', difficulty: 64, type: 'stale' })],
+      ['zadd', 'Pool1:rounds:primary:current:solo:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker1', difficulty: 32, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker3', difficulty: 8, type: 'valid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker3', difficulty: 8, type: 'invalid' })],
+      ['zadd', 'Pool1:rounds:primary:current:shared:hashrate', Date.now() / 1000, JSON.stringify({ time: 1, worker: 'worker2.w2', difficulty: 44, type: 'valid' })]];
     const response = mockResponse();
     response.on('end', (payload) => {
       const processed = JSON.parse(payload);
@@ -1057,16 +1108,25 @@ describe('Test API functionality', () => {
       expect(processed.body.primary.shared.length).toBe(3);
       expect(processed.body.primary.solo.length).toBe(1);
       expect(processed.body.primary.shared[0].worker).toBe('worker2.w1');
-      expect(processed.body.primary.shared[0].shares).toBe(64);
+      expect(processed.body.primary.shared[0].difficulty).toBe(64);
       expect(processed.body.primary.shared[0].hashrate).toBe(916259689.8133334);
+      expect(processed.body.primary.shared[0].shares.valid).toBe(1);
+      expect(processed.body.primary.shared[0].shares.stale).toBe(1);
+      expect(processed.body.primary.shared[0].shares.invalid).toBe(0);
       expect(processed.body.primary.shared[1].worker).toBe('worker2.w2');
-      expect(processed.body.primary.shared[1].shares).toBe(44);
+      expect(processed.body.primary.shared[1].difficulty).toBe(44);
       expect(processed.body.primary.shared[1].hashrate).toBe(629928536.7466667);
+      expect(processed.body.primary.shared[1].shares.valid).toBe(1);
+      expect(processed.body.primary.shared[1].shares.stale).toBe(0);
+      expect(processed.body.primary.shared[1].shares.invalid).toBe(0);
       expect(processed.body.primary.shared[2].worker).toBe('worker3');
-      expect(processed.body.primary.shared[2].shares).toBe(8);
+      expect(processed.body.primary.shared[2].difficulty).toBe(8);
       expect(processed.body.primary.shared[2].hashrate).toBe(114532461.22666667);
+      expect(processed.body.primary.shared[2].shares.valid).toBe(1);
+      expect(processed.body.primary.shared[2].shares.stale).toBe(0);
+      expect(processed.body.primary.shared[2].shares.invalid).toBe(1);
       expect(processed.body.primary.solo[0].worker).toBe('worker1');
-      expect(processed.body.primary.solo[0].shares).toBe(64);
+      expect(processed.body.primary.solo[0].difficulty).toBe(64);
       expect(processed.body.primary.solo[0].hashrate).toBe(916259689.8133334);
       done();
     });

--- a/scripts/test/api.test.js
+++ b/scripts/test/api.test.js
@@ -1024,8 +1024,6 @@ describe('Test API functionality', () => {
       expect(processed.body.primary.shares.solo.valid).toBe(0);
       expect(processed.body.primary.shares.solo.stale).toBe(0);
       expect(processed.body.primary.shares.solo.invalid).toBe(0);
-      
-      
       done();
     });
     mockSetupClient(client, commands, 'Pool1', () => {

--- a/scripts/test/utils.test.js
+++ b/scripts/test/utils.test.js
@@ -360,73 +360,73 @@ describe('Test utility functionality', () => {
 
   test('Test implemented processDifficulty [1]', () => {
     const shares = [
-      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8}',
-      '{"time":1623901919389,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8}',
-      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8}',
-      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8}'];
+      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901919389,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"valid"}'];
     expect(utils.processDifficulty(shares)).toBe(32);
   });
 
   test('Test implemented processDifficulty [2]', () => {
     const shares = [
-      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8}',
-      '{"time":1623901919389,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8}',
-      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8}',
-      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8}'];
+      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901919389,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8,"type":"valid"}'];
     expect(utils.processDifficulty(shares, 'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2', 'worker')).toBe(16);
   });
 
   test('Test implemented processDifficulty [3]', () => {
     const shares = [
-      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8}',
-      '{"time":1623901919389,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3b.worker2","solo":false,"difficulty":8}',
-      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3b.worker1","solo":false,"difficulty":8}',
-      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8}'];
+      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901919389,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3b.worker2","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3b.worker1","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8,"type":"valid"}'];
     expect(utils.processDifficulty(shares, 'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2', 'worker')).toBe(8);
   });
 
   test('Test implemented processDifficulty [4]', () => {
     const shares = [
-      '{"time":1623901893182,"solo":false,"difficulty":8}',
-      '{"time":1623901919389,"solo":false,"difficulty":8}',
-      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3b.worker1","solo":false,"difficulty":8}',
-      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8}'];
+      '{"time":1623901893182,"solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901919389,"solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3b.worker1","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8,"type":"valid"}'];
     expect(utils.processDifficulty(shares, 'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1', 'worker')).toBe(8);
   });
 
   test('Test implemented processDifficulty [5]', () => {
     const shares = [
-      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":"test"}',
-      '{"time":1623901919389,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":"test"}',
-      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8}',
-      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8}'];
+      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":"test","type":"valid"}',
+      '{"time":1623901919389,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":"test","type":"valid"}',
+      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"valid"}'];
     expect(utils.processDifficulty(shares, 'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2', 'worker')).toBe(16);
   });
 
   test('Test implemented processDifficulty [6]', () => {
     const shares = [
-      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8}',
-      '{"time":1623901919389,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8}',
-      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8}',
-      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8}'];
+      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901919389,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"valid"}'];
     expect(utils.processDifficulty(shares, 'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2', 'worker')).toBe(32);
   });
 
   test('Test implemented processDifficulty [7]', () => {
     const shares = [
-      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8}',
-      '{"time":1623901919389,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8}',
-      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8}',
-      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8}'];
+      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901919389,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"valid"}'];
     expect(utils.processDifficulty(shares, 'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a', 'miner')).toBe(32);
   });
 
   test('Test implemented processDifficulty [8]', () => {
     const shares = [
-      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8}',
-      '{"time":1623901919389,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8}',
-      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8}',
-      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8}'];
+      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901919389,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"valid"}'];
     expect(utils.processDifficulty(shares, 'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a', 'worker')).toBe(0);
   });
 
@@ -474,12 +474,14 @@ describe('Test utility functionality', () => {
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1': '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8}',
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3b.worker1': '{"time":1623901919389,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3b.worker1","solo":false,"difficulty":8}',
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1': '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1","solo":false,"difficulty":8}',
-      'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2': '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8}'};
+      'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2': '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8}',
+      'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2': '{"time":1623901949876,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8}'};
     const hashrate = [
-      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8}',
-      '{"time":1623901919389,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3b.worker1","solo":false,"difficulty":8}',
-      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1","solo":false,"difficulty":8}',
-      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8}'];
+      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901919389,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3b.worker1","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901949876,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8,"type":"stale"}'];
     const times = {
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1': 20.15,
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3b.worker1': 18.75,
@@ -489,16 +491,23 @@ describe('Test utility functionality', () => {
     expect(processed.length).toBe(3);
     expect(processed[0].miner).toBe('tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a');
     expect(processed[0].hashrate).toBe(0.02666666666666667);
-    expect(processed[0].shares).toBe(8);
+    expect(processed[0].difficulty).toBe(8);
     expect(processed[0].times).toBe(20.15);
     expect(processed[1].miner).toBe('tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3b');
     expect(processed[1].hashrate).toBe(0.02666666666666667);
-    expect(processed[1].shares).toBe(8);
+    expect(processed[1].difficulty).toBe(8);
     expect(processed[1].times).toBe(18.75);
+    expect(processed[1].shares.valid).toBe(1);
+    expect(processed[1].shares.stale).toBe(0);
+    expect(processed[1].shares.invalid).toBe(0);
     expect(processed[2].miner).toBe('tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c');
     expect(processed[2].hashrate).toBe(0.05333333333333334);
-    expect(processed[2].shares).toBe(16);
+    expect(processed[2].difficulty).toBe(16);
     expect(processed[2].times).toBe(75.15);
+    expect(typeof processed[2].shares).toBe('object');
+    expect(processed[2].shares.valid).toBe(2);
+    expect(processed[2].shares.stale).toBe(1);
+    expect(processed[2].shares.invalid).toBe(0);
   });
 
   test('Test implemented processMiners [2]', () => {
@@ -508,19 +517,19 @@ describe('Test utility functionality', () => {
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1': '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1","solo":false,"difficulty":8}',
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2': '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8}'};
     const hashrate = [
-      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8}',
-      '{"time":1623901919389,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3b.worker1","solo":false,"difficulty":8}',
-      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1","solo":false,"difficulty":8}',
-      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8}'];
+      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901919389,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3b.worker1","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8,"type":"valid"}'];
     const processed = utils.processMiners(shares, hashrate, null, 1, 300, false);
     expect(processed.length).toBe(2);
     expect(processed[0].miner).toBe('tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3b');
     expect(processed[0].hashrate).toBe(0.02666666666666667);
-    expect(processed[0].shares).toBe(8);
+    expect(processed[0].difficulty).toBe(8);
     expect(processed[0].effort).toBe(76.12);
     expect(processed[1].miner).toBe('tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c');
     expect(processed[1].hashrate).toBe(0.05333333333333334);
-    expect(processed[1].shares).toBe(16);
+    expect(processed[1].difficulty).toBe(16);
     expect(processed[1].effort).toBe(0);
   });
 
@@ -532,10 +541,10 @@ describe('Test utility functionality', () => {
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1': '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1","solo":false,"difficulty":8}',
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2': '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8}'};
     const hashrate = [
-      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8}',
-      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":0}',
-      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1","solo":false,"difficulty":8}',
-      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8}'];
+      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":0,"type":"valid"}',
+      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8,"type":"valid"}'];
     const times = {
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1': 20.15,
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2': 75.15};
@@ -543,11 +552,11 @@ describe('Test utility functionality', () => {
     expect(processed.length).toBe(2);
     expect(processed[0].miner).toBe('tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a');
     expect(processed[0].hashrate).toBe(0.02666666666666667);
-    expect(processed[0].shares).toBe(16);
+    expect(processed[0].difficulty).toBe(16);
     expect(processed[0].times).toBe(20.15);
     expect(processed[1].miner).toBe('tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c');
     expect(processed[1].hashrate).toBe(0.05333333333333334);
-    expect(processed[1].shares).toBe(16);
+    expect(processed[1].difficulty).toBe(16);
     expect(processed[1].times).toBe(75.15);
   });
 
@@ -559,9 +568,9 @@ describe('Test utility functionality', () => {
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1': '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1","solo":false,"difficulty":8}',
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2': '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8}'};
     const hashrate = [
-      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8}',
-      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1","solo":false,"difficulty":8}',
-      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8}'];
+      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8,"type":"valid"}'];
     const times = {
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1': 20.15,
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2': 18.17};
@@ -569,11 +578,11 @@ describe('Test utility functionality', () => {
     expect(processed.length).toBe(2);
     expect(processed[0].miner).toBe('tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a');
     expect(processed[0].hashrate).toBe(0.02666666666666667);
-    expect(processed[0].shares).toBe(16);
+    expect(processed[0].difficulty).toBe(16);
     expect(processed[0].times).toBe(0);
     expect(processed[1].miner).toBe('tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c');
     expect(processed[1].hashrate).toBe(0.05333333333333334);
-    expect(processed[1].shares).toBe(16);
+    expect(processed[1].difficulty).toBe(16);
     expect(processed[1].times).toBe(20.15);
   });
 
@@ -585,9 +594,9 @@ describe('Test utility functionality', () => {
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1': '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1","solo":false,"difficulty":8}',
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2': '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8}'};
     const hashrate = [
-      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8}',
-      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1","solo":false,"difficulty":8}',
-      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8}'];
+      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8,"type":"valid"}'];
     const times = {
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3b.worker1': 20.15,
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1': 20.15,
@@ -596,15 +605,15 @@ describe('Test utility functionality', () => {
     expect(processed.length).toBe(3);
     expect(processed[0].miner).toBe('tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a');
     expect(processed[0].hashrate).toBe(0.02666666666666667);
-    expect(processed[0].shares).toBe(16);
+    expect(processed[0].difficulty).toBe(16);
     expect(processed[0].times).toBe(0);
     expect(processed[1].miner).toBe('tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3b');
     expect(processed[1].hashrate).toBe(0);
-    expect(processed[1].shares).toBe(8);
+    expect(processed[1].difficulty).toBe(8);
     expect(processed[1].times).toBe(20.15);
     expect(processed[2].miner).toBe('tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c');
     expect(processed[2].hashrate).toBe(0.05333333333333334);
-    expect(processed[2].shares).toBe(16);
+    expect(processed[2].difficulty).toBe(16);
     expect(processed[2].times).toBe(20.15);
   });
 
@@ -613,9 +622,9 @@ describe('Test utility functionality', () => {
       'RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j': '{"time":1623901893182,"worker":"RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j","solo":false,"difficulty":196}',
       'RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR': '{"time":1623901893182,"worker":"RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR","solo":false,"difficulty":5517}'};
     const hashrate = [
-      '{"time":1623901893182,"worker":"RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR","solo":false,"difficulty":8}',
-      '{"time":1623901944054,"worker":"RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR","solo":false,"difficulty":8}',
-      '{"time":1623901944054,"worker":"RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR","solo":false,"difficulty":8}'];
+      '{"time":1623901893182,"worker":"RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901944054,"worker":"RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901944054,"worker":"RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR","solo":false,"difficulty":8,"type":"valid"}'];
     const times = {
       'RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j': 20.15,
       'RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR': 20530.15};
@@ -623,7 +632,7 @@ describe('Test utility functionality', () => {
     expect(processed.length).toBe(1);
     expect(processed[0].miner).toBe('RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j');
     expect(processed[0].hashrate).toBe(0.08);
-    expect(processed[0].shares).toBe(5713);
+    expect(processed[0].difficulty).toBe(5713);
     expect(processed[0].times).toBe(20530.15);
   });
 
@@ -749,6 +758,62 @@ describe('Test utility functionality', () => {
     expect(Object.keys(processed).length).toBe(0);
   });
 
+  test('Test implemented processShareTypes [1]', () => {
+    const shares = [
+      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901919389,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"stale"}',
+      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"invalid"}'];
+    const processed = utils.processShareTypes(shares, 'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2', 'worker');
+    expect(Object.keys(processed).length).toBe(3);
+    expect(processed['valid']).toBe(2);
+    expect(processed['stale']).toBe(1);
+    expect(processed['invalid']).toBe(1);
+  });
+
+  test('Test implemented processShareTypes [2]', () => {
+    const shares = [
+      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901919389,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"stale"}',
+      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"difficulty":8,"type":"invalid"}'];
+    const processed = utils.processShareTypes(shares, 'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a', 'miner');
+    expect(Object.keys(processed).length).toBe(3);
+    expect(processed['valid']).toBe(3);
+    expect(processed['stale']).toBe(1);
+    expect(processed['invalid']).toBe(1);
+  });
+
+  test('Test implemented processShareTypes [3]', () => {
+    const processed = utils.processShareTypes(null, 'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a', 'miner');
+    expect(Object.keys(processed).length).toBe(3);
+    expect(processed['valid']).toBe(0);
+    expect(processed['stale']).toBe(0);
+    expect(processed['invalid']).toBe(0);
+  });
+
+  test('Test implemented processShareTypes [4]', () => {
+    const shares = [
+      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8}'];
+    const processed = utils.processShareTypes(shares, 'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a', 'miner');
+    expect(Object.keys(processed).length).toBe(3);
+    expect(processed['valid']).toBe(0);
+    expect(processed['stale']).toBe(0);
+    expect(processed['invalid']).toBe(0);
+  });
+
+  test('Test implemented processShareTypes [5]', () => {
+    const shares = [
+      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8,"type":"something_else"}'];
+    const processed = utils.processShareTypes(shares, 'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a', 'miner');
+    expect(Object.keys(processed).length).toBe(3);
+    expect(processed['valid']).toBe(0);
+    expect(processed['stale']).toBe(0);
+    expect(processed['invalid']).toBe(0);
+  });
+
   test('Test implemented processTimes [1]', () => {
     const times = {
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1': '0',
@@ -815,12 +880,14 @@ describe('Test utility functionality', () => {
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1': '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8}',
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3b.worker1': '{"time":1623901919389,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3b.worker1","solo":false,"difficulty":8}',
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1': '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1","solo":false,"difficulty":8}',
-      'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2': '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8}'};
+      'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2': '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8}',
+      'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2': '{"time":1623901998765,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8}'};
     const hashrate = [
-      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8}',
-      '{"time":1623901919389,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3b.worker1","solo":false,"difficulty":8}',
-      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1","solo":false,"difficulty":8}',
-      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8}'];
+      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901919389,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3b.worker1","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8,"type":"stale"}'];
     const times = {
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1': 20.15,
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3b.worker1': 18.75,
@@ -830,20 +897,27 @@ describe('Test utility functionality', () => {
     expect(processed.length).toBe(4);
     expect(processed[0].worker).toBe('tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1');
     expect(processed[0].hashrate).toBe(0.02666666666666667);
-    expect(processed[0].shares).toBe(8);
+    expect(processed[0].difficulty).toBe(8);
     expect(processed[0].times).toBe(20.15);
     expect(processed[1].worker).toBe('tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3b.worker1');
     expect(processed[1].hashrate).toBe(0.02666666666666667);
-    expect(processed[1].shares).toBe(8);
+    expect(processed[1].difficulty).toBe(8);
     expect(processed[1].times).toBe(18.75);
     expect(processed[2].worker).toBe('tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1');
     expect(processed[2].hashrate).toBe(0.02666666666666667);
-    expect(processed[2].shares).toBe(8);
+    expect(processed[2].difficulty).toBe(8);
     expect(processed[2].times).toBe(16.14);
+    expect(processed[2].shares.valid).toBe(1);
+    expect(processed[2].shares.stale).toBe(0);
+    expect(processed[2].shares.invalid).toBe(0);
     expect(processed[3].worker).toBe('tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2');
     expect(processed[3].hashrate).toBe(0.02666666666666667);
-    expect(processed[3].shares).toBe(8);
+    expect(processed[3].difficulty).toBe(8);
     expect(processed[3].times).toBe(75.15);
+    expect(typeof processed[3].shares).toBe('object');
+    expect(processed[3].shares.valid).toBe(1);
+    expect(processed[3].shares.stale).toBe(1);
+    expect(processed[3].shares.invalid).toBe(0);
   });
 
   test('Test implemented processWorkers [2]', () => {
@@ -853,22 +927,22 @@ describe('Test utility functionality', () => {
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1': '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1","solo":false,"difficulty":8}',
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2': '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8}'};
     const hashrate = [
-      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8}',
-      '{"time":1623901919389,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3b.worker1","solo":false,"difficulty":8}',
-      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1","solo":false,"difficulty":8}',
-      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8}'];
+      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901919389,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3b.worker1","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8,"type":"valid"}'];
     const processed = utils.processWorkers(shares, hashrate, null, 1, 300, false);
     expect(processed.length).toBe(3);
     expect(processed[0].worker).toBe('tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1');
     expect(processed[0].hashrate).toBe(0.02666666666666667);
-    expect(processed[0].shares).toBe(8);
+    expect(processed[0].difficulty).toBe(8);
     expect(processed[0].effort).toBe(16.15);
     expect(processed[1].worker).toBe('tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1');
     expect(processed[1].hashrate).toBe(0.02666666666666667);
-    expect(processed[1].shares).toBe(8);
+    expect(processed[1].difficulty).toBe(8);
     expect(processed[2].worker).toBe('tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2');
     expect(processed[2].hashrate).toBe(0.02666666666666667);
-    expect(processed[2].shares).toBe(8);
+    expect(processed[2].difficulty).toBe(8);
   });
 
   test('Test implemented processWorkers [3]', () => {
@@ -878,8 +952,8 @@ describe('Test utility functionality', () => {
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1': '{"time":1623901929800,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker1","solo":false,"difficulty":8}',
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2': '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8}'};
     const hashrate = [
-      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8}',
-      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8}'];
+      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901944054,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2","solo":false,"difficulty":8,"type":"valid"}'];
     const times = {
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1': 20.15,
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2': 75.15};
@@ -887,11 +961,11 @@ describe('Test utility functionality', () => {
     expect(processed.length).toBe(2);
     expect(processed[0].worker).toBe('tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1');
     expect(processed[0].hashrate).toBe(0.02666666666666667);
-    expect(processed[0].shares).toBe(8);
+    expect(processed[0].difficulty).toBe(8);
     expect(processed[0].times).toBe(20.15);
     expect(processed[1].worker).toBe('tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3c.worker2');
     expect(processed[1].hashrate).toBe(0.02666666666666667);
-    expect(processed[1].shares).toBe(8);
+    expect(processed[1].difficulty).toBe(8);
     expect(processed[1].times).toBe(75.15);
   });
 
@@ -900,9 +974,9 @@ describe('Test utility functionality', () => {
       'RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j': '{"time":1623901893182,"worker":"RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j","solo":false,"difficulty":196}',
       'RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR': '{"time":1623901893182,"worker":"RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR","solo":false,"difficulty":5517}'};
     const hashrate = [
-      '{"time":1623901893182,"worker":"RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR","solo":false,"difficulty":8}',
-      '{"time":1623901944054,"worker":"RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR","solo":false,"difficulty":8}',
-      '{"time":1623901944054,"worker":"RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR","solo":false,"difficulty":8}'];
+      '{"time":1623901893182,"worker":"RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901944054,"worker":"RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901944054,"worker":"RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR","solo":false,"difficulty":8,"type":"valid"}'];
     const times = {
       'RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j': 20.15,
       'RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR': 20530.15};
@@ -910,7 +984,7 @@ describe('Test utility functionality', () => {
     expect(processed.length).toBe(1);
     expect(processed[0].worker).toBe('RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR');
     expect(processed[0].hashrate).toBe(0.08);
-    expect(processed[0].shares).toBe(5517);
+    expect(processed[0].difficulty).toBe(5517);
     expect(processed[0].times).toBe(20530.15);
   });
 
@@ -919,9 +993,9 @@ describe('Test utility functionality', () => {
       'RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j': '{"time":1623901893182,"worker":"RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j","solo":false,"difficulty":196}',
       'RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR': '{"time":1623901893182,"worker":"RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR","solo":false,"difficulty":5517}'};
     const hashrate = [
-      '{"time":1623901893182,"worker":"RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR","solo":false,"difficulty":8}',
-      '{"time":1623901944054,"worker":"RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR","solo":false,"difficulty":8}',
-      '{"time":1623901944054,"worker":"RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR","solo":false,"difficulty":8}'];
+      '{"time":1623901893182,"worker":"RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901944054,"worker":"RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR","solo":false,"difficulty":8,"type":"valid"}',
+      '{"time":1623901944054,"worker":"RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR","solo":false,"difficulty":8,"type":"valid"}'];
     const times = {
       'RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j': 20.15,
       'RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR': 20530.15};
@@ -929,11 +1003,11 @@ describe('Test utility functionality', () => {
     expect(processed.length).toBe(2);
     expect(processed[0].worker).toBe('RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j');
     expect(processed[0].hashrate).toBe(0);
-    expect(processed[0].shares).toBe(196);
+    expect(processed[0].difficulty).toBe(196);
     expect(processed[0].times).toBe(20.15);
     expect(processed[1].worker).toBe('RFeE924XmUhqJqUpRJykryxumNBwiMfZ4j.minerLHR');
     expect(processed[1].hashrate).toBe(0.08);
-    expect(processed[1].shares).toBe(5517);
+    expect(processed[1].difficulty).toBe(5517);
     expect(processed[1].times).toBe(20530.15);
   });
 


### PR DESCRIPTION
1. Share types (valid/invalid/stale) are introduced at worker/miner level and saved to Redis (:hashrate).
2. Since "shares" are now used for shareType in the API, "shares" are renamed to "difficulty". Variable names changed for consistency.
3. Worker/miner-specific APIs are redesigned to give more detail (general miner/worker API structure has not been changed at this stage).