### PR TITLE
Identified hashrate for API use

### DIFF
--- a/scripts/main/statistics.js
+++ b/scripts/main/statistics.js
@@ -48,8 +48,8 @@ const PoolStatistics = function (logger, client, poolConfig, portalConfig) {
     const output = {
       time: dateNow,
       hashrate: {
-        shared: (multiplier * utils.processWork(results[1])) / _this.hashrateWindow,
-        solo: (multiplier * utils.processWork(results[2])) / _this.hashrateWindow,
+        shared: utils.processIdentifiedWork(results[1], multiplier, _this.hashrateWindow),
+        solo: utils.processIdentifiedWork(results[2], multiplier, _this.hashrateWindow),
       },
       network: {
         difficulty: parseFloat((results[0] || {}).difficulty || 0),

--- a/scripts/main/utils.js
+++ b/scripts/main/utils.js
@@ -170,6 +170,9 @@ exports.listIdentifiers = function(shares) {
         }
     });
   }
+  if (output.length == 0) {
+    output = 'default';
+  }
   return output;
 };
 

--- a/scripts/main/utils.js
+++ b/scripts/main/utils.js
@@ -156,6 +156,23 @@ exports.listBlocks = function(blocks, address) {
   return output;
 };
 
+// List Share Identifiers
+exports.listIdentifiers = function(shares) {
+  const output = [];
+  if (shares) {
+    shares = shares
+      .map((share) => JSON.parse(share))
+      .forEach((share) => {
+        if (share.identifier) {
+          if (!(output.includes(share.identifier))) {
+            output.push(share.identifier);
+          }
+        }
+    });
+  }
+  return output;
+};
+
 // List Round Workers for API Endpoints
 exports.listWorkers = function(shares, address) {
   const workers = [];
@@ -212,6 +229,33 @@ exports.processHistorical = function(history) {
   if (history) {
     history.forEach((entry) => {
       output.push(JSON.parse(entry));
+    });
+  }
+  return output;
+};
+
+// Process Work for API Endpoints with Identifier
+exports.processIdentifiedWork = function(shares, multiplier, hashrateWindow) {
+  const output = [];
+  if (shares) {
+    const identifiers = exports.listIdentifiers(shares);
+    shares = shares.map((share) => JSON.parse(share));
+    identifiers.forEach((entry) => {
+      let totalWork = 0;
+      shares = shares
+        .filter((share) => entry === share.identifier)
+        .forEach((share) => {
+          if (share.worker && share.work) {
+            const workValue = /^-?\d*(\.\d+)?$/.test(share.work) ? parseFloat(share.work) : 0;
+            totalWork += workValue;
+          }
+        });
+      const hashrateValue = (multiplier * totalWork / hashrateWindow);
+      const outputValue = {
+        identifier: entry,
+        hashrate: hashrateValue
+      };
+      output.push(outputValue);
     });
   }
   return output;


### PR DESCRIPTION
Created two new util functions which help in creating a new data structure in :historical. Hashrate is now stored as an array split into individual objects according to originating identifier.

hashrate: { shared: [{identifier, hashrate}, ...], ...}

Please review draft and let me know what to change before I fix relevant tests.