### PR TITLE
Historic hashrate with identifiers

### DIFF
--- a/scripts/main/statistics.js
+++ b/scripts/main/statistics.js
@@ -48,8 +48,8 @@ const PoolStatistics = function (logger, client, poolConfig, portalConfig) {
     const output = {
       time: dateNow,
       hashrate: {
-        shared: (multiplier * utils.processWork(results[1])) / _this.hashrateWindow,
-        solo: (multiplier * utils.processWork(results[2])) / _this.hashrateWindow,
+        shared: utils.processIdentifiedWork(results[1], multiplier, _this.hashrateWindow),
+        solo: utils.processIdentifiedWork(results[2], multiplier, _this.hashrateWindow),
       },
       network: {
         difficulty: parseFloat((results[0] || {}).difficulty || 0),

--- a/scripts/main/utils.js
+++ b/scripts/main/utils.js
@@ -156,6 +156,26 @@ exports.listBlocks = function(blocks, address) {
   return output;
 };
 
+// List Share Identifiers
+exports.listIdentifiers = function(shares) {
+  const output = [];
+  if (shares) {
+    shares = shares
+      .map((share) => JSON.parse(share))
+      .forEach((share) => {
+        if (share.identifier || share.identifier == '') {
+          if (!(output.includes(share.identifier))) {
+            output.push(share.identifier);
+          }
+        }
+    });
+  }
+  if (output.length == 0) {
+    return [''];
+  }
+  return output;
+};
+
 // List Round Workers for API Endpoints
 exports.listWorkers = function(shares, address) {
   const workers = [];
@@ -212,6 +232,23 @@ exports.processHistorical = function(history) {
   if (history) {
     history.forEach((entry) => {
       output.push(JSON.parse(entry));
+    });
+  }
+  return output;
+};
+
+// Process Work for API Endpoints with Identifier
+exports.processIdentifiedWork = function(shares, multiplier, hashrateWindow) {
+  const output = [];
+  if (shares) {
+    let identifiers = exports.listIdentifiers(shares);
+    identifiers.forEach((entry) => {
+      const hashrateValue = exports.processWork(shares, null, null, entry);
+      const outputValue = {
+        identifier: entry,
+        hashrate: (multiplier * hashrateValue) / hashrateWindow
+      };
+      output.push(outputValue);
     });
   }
   return output;
@@ -375,10 +412,13 @@ exports.processTypes = function(shares, address, type) {
 };
 
 // Process Work for API Endpoints
-exports.processWork = function(shares, address, type) {
+exports.processWork = function(shares, address, type, identifier) {
   let output = 0;
   if (shares) {
     shares = shares.map((share) => JSON.parse(share));
+    if (identifier && identifier != '') {
+      shares = shares.filter((share) => identifier === share.identifier)
+    }
     shares.forEach((share) => {
       if (share.worker && share.work) {
         const worker = share.worker.split('.')[0];

--- a/scripts/test/statistics.test.js
+++ b/scripts/test/statistics.test.js
@@ -68,7 +68,7 @@ describe('Test statistics functionality', () => {
       ['{"time":1644418236973,"work":1,"identifier":"","effort":2.777761938931719,"worker":"QRspi5xuc5oaxfNzJD5Pqr9vMNLbF56L3N.worker1","solo":true,"round":"ff40848b"}',
         '{"time":1644418236974,"work":1,"identifier":"","effort":2.777761938931719,"worker":"QRspi5xuc5oaxfNzJD5Pqr9vMNLbF56L3N.worker2","solo":true,"round":"ff40848b"}'], 0];
     const expected = [
-      ['zadd', 'Pool1:statistics:primary:historical', 1637878085, '{"time":1637878085886,"hashrate":{"shared":28633115.30666667,"solo":28633115.30666667},"network":{"difficulty":1.092031593681264,"hashrate":30793089.90778545},"status":{"miners":2,"workers":4}}']];
+      ['zadd', 'Pool1:statistics:primary:historical', 1637878085, '{"time":1637878085886,"hashrate":{"shared":[{"identifier":"","hashrate":28633115.30666667}],"solo":[{"identifier":"","hashrate":28633115.30666667}]},"network":{"difficulty":1.092031593681264,"hashrate":30793089.90778545},"status":{"miners":2,"workers":4}}']];
     const processed = poolStatistics.calculateHistoricalInfo(results, 'primary');
     expect(processed).toStrictEqual(expected);
   });
@@ -107,7 +107,7 @@ describe('Test statistics functionality', () => {
       ['hset', 'Pool1:statistics:primary:network', 'hashrate', 52007.68563030699],
       ['hset', 'Pool1:statistics:primary:network', 'height', 611207]];
     const expected = [
-      ['zadd', 'Pool1:statistics:primary:historical', 1637878085, '{"time":1637878085886,"hashrate":{"shared":0,"solo":0},"network":{"difficulty":0.001978989105730653,"hashrate":52007.68563030699},"status":{"miners":0,"workers":0}}']];
+      ['zadd', 'Pool1:statistics:primary:historical', 1637878085, '{"time":1637878085886,"hashrate":{"shared":[{"identifier":"","hashrate":0}],"solo":[{"identifier":"","hashrate":0}]},"network":{"difficulty":0.001978989105730653,"hashrate":52007.68563030699},"status":{"miners":0,"workers":0}}']];
     mockSetupClient(client, commands, 'Pool1', () => {
       poolStatistics.handleHistoricalInfo('primary', (output) => {
         expect(output).toStrictEqual(expected);
@@ -124,7 +124,7 @@ describe('Test statistics functionality', () => {
     const commands = [
       ['hset', 'Pool1:statistics:primary:network', 'height', 611207]];
     const expected = [
-      ['zadd', 'Pool1:statistics:primary:historical', 1637878085, '{"time":1637878085886,"hashrate":{"shared":0,"solo":0},"network":{"difficulty":0,"hashrate":0},"status":{"miners":0,"workers":0}}']];
+      ['zadd', 'Pool1:statistics:primary:historical', 1637878085, '{"time":1637878085886,"hashrate":{"shared":[{"identifier":"","hashrate":0}],"solo":[{"identifier":"","hashrate":0}]},"network":{"difficulty":0,"hashrate":0},"status":{"miners":0,"workers":0}}']];
     mockSetupClient(client, commands, 'Pool1', () => {
       poolStatistics.handleHistoricalInfo('primary', (output) => {
         expect(output).toStrictEqual(expected);
@@ -137,7 +137,7 @@ describe('Test statistics functionality', () => {
     MockDate.set(1637878085886);
     const poolStatistics = new PoolStatistics(logger, client, poolConfigCopy, configCopy);
     const expected = [
-      ['zadd', 'Pool1:statistics:primary:historical', 1637878085, '{"time":1637878085886,"hashrate":{"shared":0,"solo":0},"network":{"difficulty":0,"hashrate":0},"status":{"miners":0,"workers":0}}']];
+      ['zadd', 'Pool1:statistics:primary:historical', 1637878085, '{"time":1637878085886,"hashrate":{"shared":[{"identifier":"","hashrate":0}],"solo":[{"identifier":"","hashrate":0}]},"network":{"difficulty":0,"hashrate":0},"status":{"miners":0,"workers":0}}']];
     poolStatistics.handleHistoricalInfo('primary', (output) => {
       expect(output).toStrictEqual(expected);
       done();

--- a/scripts/test/utils.test.js
+++ b/scripts/test/utils.test.js
@@ -268,6 +268,45 @@ describe('Test utility functionality', () => {
     expect(processed).toStrictEqual([]);
   });
 
+  test('Test implemented listIdentifiers [1]', () => {
+    const shares = [
+      '{"time":1623901893182,"identifier":"","worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"work":8}'];
+    const expected = [''];
+    const processed = utils.listIdentifiers(shares);
+    expect(processed).toStrictEqual(expected);
+  });
+
+  test('Test implemented listIdentifiers [2]', () => {
+    const shares = [
+      '{"time":1623901893182,"identifier":"a","worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"work":8}',
+      '{"time":1623901893182,"identifier":"b","worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"work":8}'];
+    const expected = ['a', 'b'];
+    const processed = utils.listIdentifiers(shares);
+    expect(processed).toStrictEqual(expected);
+  });
+
+  test('Test implemented listIdentifiers [3]', () => {
+    const shares = [
+      '{"time":1623901893182,"identifier":"a","worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"work":8}',
+      '{"time":1623901893182,"identifier":"","worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"work":8}'];
+    const expected = ['a', ''];
+    const processed = utils.listIdentifiers(shares);
+    expect(processed).toStrictEqual(expected);
+  });
+
+  test('Test implemented listIdentifiers [4]', () => {
+    const processed = utils.listIdentifiers(null);
+    expect(processed).toStrictEqual(['']);
+  });
+
+  test('Test implemented listIdentifiers [5]', () => {
+    const shares = [
+      '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"work":8}'];
+    const expected = [''];
+    const processed = utils.listIdentifiers(shares);
+    expect(processed).toStrictEqual(expected);
+  });
+
   test('Test implemented listWorkers [1]', () => {
     const shares = {
       'tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2': '{"time":1623901893182,"worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"work":8}'};
@@ -374,6 +413,24 @@ describe('Test utility functionality', () => {
 
   test('Test implemented processHistorical [2]', () => {
     expect(utils.processHistorical(null)).toStrictEqual([]);
+  });
+
+  test('Test implemented processIdentifiedWork [1]', () => {
+    const multiplier = 10;
+    const hashrateWindow = 10;
+    const processed = utils.processIdentifiedWork(null, multiplier, hashrateWindow);
+    const expected = [];
+    expect(processed).toStrictEqual(expected);
+  });
+
+  test('Test implemented processIdentifiedWork [2]', () => {
+    const shares = [
+      '{"time":1623901893182,"identifier":"a","worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker1","times":20.15,"solo":false,"types":{"valid":1,"invalid":0,"stale":0},"work":8}']
+    const multiplier = 10;
+    const hashrateWindow = 10;
+    const processed = utils.processIdentifiedWork(shares, multiplier, hashrateWindow);
+    const expected = [{"hashrate": 8,"identifier":"a"}];
+    expect(processed).toStrictEqual(expected);
   });
 
   test('Test implemented processLuck [1]', () => {
@@ -886,6 +943,14 @@ describe('Test utility functionality', () => {
     expect(utils.processWork(null)).toBe(0);
   });
 
+  test('Test implemented processWork [10]', () => {
+    const shares = [
+      '{"time":1623901893182,"identifier":"a","worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"work":8}',
+      '{"time":1623901919389,"identifier":"a","worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"work":8}',
+      '{"time":1623901929800,"identifier":"","worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"work":8}',
+      '{"time":1623901944054,"identifier":"","worker":"tltc1qkek8r3uymzqyajzezqgl84u08c0z8shjuwqv3a.worker2","solo":false,"work":8}'];
+    expect(utils.processWork(shares, null, null, 'a')).toBe(16);
+  });
 
   test('Test implemented processWorkers [1]', () => {
     const shares = {


### PR DESCRIPTION
Created two new util functions which help in creating a new data structure in :historical. Hashrate is now stored as an array split into individual objects according to originating identifier.

hashrate: { shared: [{identifier, hashrate}, ...], ...}